### PR TITLE
Added Item base and 2 test items

### DIFF
--- a/items/item_base.gd
+++ b/items/item_base.gd
@@ -1,0 +1,26 @@
+class_name Item
+extends Area3D
+
+## This is the base item. 
+
+@export var item_name: String = "Base Item"
+
+var is_held: bool = false
+
+func _ready() -> void:
+	self.body_entered.connect(_on_body_entered)
+
+func _on_body_entered(body: Node3D) -> void:
+	if is_held || !body.is_in_group("Player"): return
+	if body.has_method("pick_up_item"): 
+		body.pick_up_item.call_deferred(self)
+	else:
+		print("Player does not have pick_up_item function!")
+	
+	
+
+func use() -> void:
+	if !is_held: print("Item was used while not held, WTF?")
+	else:
+		print("Base Item used.")
+		queue_free()

--- a/items/item_base.gd
+++ b/items/item_base.gd
@@ -1,7 +1,9 @@
 class_name Item
 extends Area3D
 
-## This is the base item. 
+## This is the base item. The item as it exists in the player's hand, inventory, and lying around the world are all the same thing.
+## Create an inherited scene from res://items/item_base.tscn, then create a script that extends Item with a unique use() function to create a new item.
+## You can also change the item_name string in the inspector, which will probably show in the HUD.
 
 @export var item_name: String = "Base Item"
 
@@ -11,14 +13,17 @@ func _ready() -> void:
 	self.body_entered.connect(_on_body_entered)
 
 func _on_body_entered(body: Node3D) -> void:
+	# Items don't care about collisions if they're from non-players or if the item is already held.
 	if is_held || !body.is_in_group("Player"): return
 	if body.has_method("pick_up_item"): 
+		# We call deferred because this is physics and getting picked up involves reparenting.
+		# No fucking with the scene tree before physics is done happening!
 		body.pick_up_item.call_deferred(self)
 	else:
 		print("Player does not have pick_up_item function!")
 	
 	
-
+## The generic use function. You can write your own in a class that extends Item.
 func use() -> void:
 	if !is_held: print("Item was used while not held, WTF?")
 	else:

--- a/items/item_base.gd
+++ b/items/item_base.gd
@@ -20,12 +20,12 @@ func _on_body_entered(body: Node3D) -> void:
 		# No fucking with the scene tree before physics is done happening!
 		body.pick_up_item.call_deferred(self)
 	else:
-		print("Player does not have pick_up_item function!")
+		Debug.log_err("Player does not have pick_up_item function!")
 	
 	
 ## The generic use function. You can write your own in a class that extends Item.
 func use() -> void:
-	if !is_held: print("Item was used while not held, WTF?")
+	if !is_held: Debug.log_err("Item was used while not held, WTF?")
 	else:
-		print("Base Item used.")
+		Debug.log("Base Item used.")
 		queue_free()

--- a/items/item_base.gd.uid
+++ b/items/item_base.gd.uid
@@ -1,0 +1,1 @@
+uid://b53s0xyvnpnrm

--- a/items/item_base.tscn
+++ b/items/item_base.tscn
@@ -1,0 +1,17 @@
+[gd_scene format=3 uid="uid://wxoi06uuc45h"]
+
+[ext_resource type="Script" uid="uid://b53s0xyvnpnrm" path="res://items/item_base.gd" id="1_5ufc5"]
+[ext_resource type="Texture2D" uid="uid://b3tmja6unn2ao" path="res://temp/temp_art/tmplogo.png" id="2_8ndl7"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_et2oy"]
+radius = 1.6796818
+
+[node name="Item" type="Area3D" unique_id=1566519324]
+script = ExtResource("1_5ufc5")
+
+[node name="Sprite3D" type="Sprite3D" parent="." unique_id=525106753]
+billboard = 1
+texture = ExtResource("2_8ndl7")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="." unique_id=829023768]
+shape = SubResource("SphereShape3D_et2oy")

--- a/items/item_test_1.gd
+++ b/items/item_test_1.gd
@@ -1,0 +1,7 @@
+extends Item
+
+func use() -> void:
+	if !is_held: print("Item was used while not held, WTF?")
+	else:
+		print("I'm item_test_1!! I'm fuckin awesome!!!")
+		queue_free()

--- a/items/item_test_1.gd
+++ b/items/item_test_1.gd
@@ -1,7 +1,7 @@
 extends Item
 
 func use() -> void:
-	if !is_held: print("Item was used while not held, WTF?")
+	if !is_held: Debug.log_err("Item was used while not held, WTF?")
 	else:
-		print("I'm item_test_1!! I'm fuckin awesome!!!")
+		Debug.log("I'm item_test_1!! I'm fuckin awesome!!!")
 		queue_free()

--- a/items/item_test_1.gd.uid
+++ b/items/item_test_1.gd.uid
@@ -1,0 +1,1 @@
+uid://cav0ipajdsvbf

--- a/items/item_test_1.tscn
+++ b/items/item_test_1.tscn
@@ -1,0 +1,11 @@
+[gd_scene format=3 uid="uid://dsnep0jd62s78"]
+
+[ext_resource type="PackedScene" uid="uid://wxoi06uuc45h" path="res://items/item_base.tscn" id="1_ww0im"]
+[ext_resource type="Script" uid="uid://cav0ipajdsvbf" path="res://items/item_test_1.gd" id="2_upf11"]
+
+[node name="ItemTest1" unique_id=1566519324 instance=ExtResource("1_ww0im")]
+script = ExtResource("2_upf11")
+item_name = "Test 1"
+
+[node name="Sprite3D" parent="." index="0" unique_id=525106753]
+modulate = Color(0.38, 0.8036667, 1, 1)

--- a/items/item_test_2.gd
+++ b/items/item_test_2.gd
@@ -1,7 +1,7 @@
 extends Item
 
 func use() -> void:
-	if !is_held: print("Item was used while not held, WTF?")
+	if !is_held: Debug.log_err("Item was used while not held, WTF?")
 	else:
-		print("My name is item_test_2 and I'm just O.K. That's all. Take care.")
+		Debug.log("My name is item_test_2 and I'm just O.K. That's all. Take care.")
 		queue_free()

--- a/items/item_test_2.gd
+++ b/items/item_test_2.gd
@@ -1,0 +1,7 @@
+extends Item
+
+func use() -> void:
+	if !is_held: print("Item was used while not held, WTF?")
+	else:
+		print("My name is item_test_2 and I'm just O.K. That's all. Take care.")
+		queue_free()

--- a/items/item_test_2.gd.uid
+++ b/items/item_test_2.gd.uid
@@ -1,0 +1,1 @@
+uid://d221j7c4ucih3

--- a/items/item_test_2.tscn
+++ b/items/item_test_2.tscn
@@ -1,0 +1,11 @@
+[gd_scene format=3 uid="uid://ck8obcgulgo8p"]
+
+[ext_resource type="PackedScene" uid="uid://wxoi06uuc45h" path="res://items/item_base.tscn" id="1_qegak"]
+[ext_resource type="Script" uid="uid://d221j7c4ucih3" path="res://items/item_test_2.gd" id="2_078a7"]
+
+[node name="Item" unique_id=1566519324 instance=ExtResource("1_qegak")]
+script = ExtResource("2_078a7")
+item_name = "Test 2"
+
+[node name="Sprite3D" parent="." index="0" unique_id=525106753]
+modulate = Color(1, 0.20999998, 0.20999998, 1)

--- a/player/player.gd
+++ b/player/player.gd
@@ -41,9 +41,10 @@ func pick_up_item(item: Item) -> void:
 	held_item.is_held = true
 	held_item.position = Vector3.ZERO
 
-@rpc("call_local")
+@rpc("authority","call_local")
 func use_held_item() -> void:
 	# If you don't have an item, don't try and use a nonexistent item.
 	if held_item==null:return
+	
 	held_item.use()
 	held_item=null

--- a/player/player.gd
+++ b/player/player.gd
@@ -2,7 +2,7 @@ class_name Player
 extends CharacterBody3D
 
 @export var speed := 10.
-@export var held_item: Item
+var held_item: Item
 
 var last_pos : Vector3 = Vector3.ZERO
 

--- a/player/player.gd
+++ b/player/player.gd
@@ -41,10 +41,9 @@ func pick_up_item(item: Item) -> void:
 	held_item.is_held = true
 	held_item.position = Vector3.ZERO
 
-@rpc("authority","call_local")
+@rpc("call_local")
 func use_held_item() -> void:
 	# If you don't have an item, don't try and use a nonexistent item.
 	if held_item==null:return
-	
 	held_item.use()
 	held_item=null

--- a/player/player.gd
+++ b/player/player.gd
@@ -2,8 +2,10 @@ class_name Player
 extends CharacterBody3D
 
 @export var speed := 10.
+@export var held_item: Item
 
 var last_pos : Vector3 = Vector3.ZERO
+
 
 func _process(_delta: float) -> void:
 	if not is_multiplayer_authority(): 
@@ -17,9 +19,31 @@ func _process(_delta: float) -> void:
 	move_and_slide()
 
 func _input(event: InputEvent) -> void:
+	if not is_multiplayer_authority(): return
 	if event.is_action_pressed("print_players"):
 		Debug.print_players()
+	if event.is_action_pressed("use_item"):
+		#TODO: Don't let this happen if the player is aiming.
+		use_held_item.rpc()
 
 @rpc("unreliable_ordered")
 func sync_velocity(vel: Vector3) -> void:
 	velocity = vel
+
+func pick_up_item(item: Item) -> void:
+	# TODO: Parent it to the player's hand?
+	# I imagine there might even be item-specific animations, but I think this should be extendable enough to accomodate that. Imagine an enum of item hold anim types and the item just reports which one it uses...
+	
+	# If you already have an item, don't pick up another one.
+	if held_item!=null: return
+	item.reparent(self, false)
+	held_item = item
+	held_item.is_held = true
+	held_item.position = Vector3.ZERO
+
+@rpc("call_local")
+func use_held_item() -> void:
+	# If you don't have an item, don't try and use a nonexistent item.
+	if held_item==null:return
+	held_item.use()
+	held_item=null

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://bffxe171rcnea"]
+[gd_scene format=3 uid="uid://bffxe171rcnea"]
 
 [ext_resource type="Script" uid="uid://bx8rb13al7o7e" path="res://player/player.gd" id="1_onrkg"]
 
@@ -11,18 +11,18 @@ properties/0/path = NodePath(".:position")
 properties/0/spawn = true
 properties/0/replication_mode = 1
 
-[node name="Player" type="CharacterBody3D"]
+[node name="Player" type="CharacterBody3D" unique_id=1653185810 groups=["Player"]]
 collision_mask = 0
 motion_mode = 1
 script = ExtResource("1_onrkg")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=951967374]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 mesh = SubResource("CapsuleMesh_oul6g")
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="." unique_id=1812883740]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 shape = SubResource("CapsuleShape3D_rkbax")
 
-[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="."]
+[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="." unique_id=1979522579]
 replication_config = SubResource("SceneReplicationConfig_onrkg")

--- a/project.godot
+++ b/project.godot
@@ -30,6 +30,10 @@ folder_colors={
 "res://temp/": "gray"
 }
 
+[global_group]
+
+Player=""
+
 [input]
 
 move_left={

--- a/systems/debug.gd
+++ b/systems/debug.gd
@@ -10,21 +10,15 @@ enum LogMode{
 
 func client_id() -> String:
 	return str(multiplayer.get_unique_id()).lpad(10,"0")
-	
-func log(...args: Array) -> void:
-	var uid : int = multiplayer.get_unique_id()
-	if log_mode == LogMode.SERVER && uid != 1:
-		return
-	if log_mode == LogMode.CLIENT && uid == 1:
-		return
-	
+
+func create_debug_string(args: Array) -> String:
 	var output : String = "["+client_id()+"] "
 
 	# get caller
 	if OS.is_debug_build():
 		# 0 = us
 		# 1 = caller
-		var caller: Dictionary = get_stack()[1]
+		var caller: Dictionary = get_stack()[2]
 		var source_file: String = caller.source
 		source_file = source_file.split('/')[-1]
 		output += ("[%s:%d]" % [source_file, caller.line])
@@ -33,7 +27,24 @@ func log(...args: Array) -> void:
 
 	for s in args:
 		output += str(s)
-	print(output)
+	return output
+
+func log_mode_enabled() -> bool:
+	var uid : int = multiplayer.get_unique_id()
+	if log_mode == LogMode.SERVER && uid != 1:
+		return false
+	if log_mode == LogMode.CLIENT && uid == 1:
+		return false
+	return true
+
+func log(...args: Array) -> void:
+	if not log_mode_enabled():
+		return
+	print(create_debug_string(args))
+
+func log_err(... args: Array) -> void:
+	push_error(create_debug_string(args))
+
 
 func print_players() -> void:
 	print("["+client_id()+"] Detected Players:")

--- a/systems/debug.tscn
+++ b/systems/debug.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://hc1ks0khr40u"]
+[gd_scene format=3 uid="uid://hc1ks0khr40u"]
 
 [ext_resource type="Script" uid="uid://cnc8f7m4m578u" path="res://systems/debug.gd" id="1_rkv63"]
 
-[node name="Debug" type="Node"]
+[node name="Debug" type="Node" unique_id=585069978]
 script = ExtResource("1_rkv63")

--- a/temp/temp_art/tmplogo.png.import
+++ b/temp/temp_art/tmplogo.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b3tmja6unn2ao"
-path="res://.godot/imported/tmplogo.png-ff6cef480fc254afef13fb4e46f0c03b.ctex"
+path.s3tc="res://.godot/imported/tmplogo.png-ff6cef480fc254afef13fb4e46f0c03b.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://temp/temp_art/tmplogo.png"
-dest_files=["res://.godot/imported/tmplogo.png-ff6cef480fc254afef13fb4e46f0c03b.ctex"]
+dest_files=["res://.godot/imported/tmplogo.png-ff6cef480fc254afef13fb4e46f0c03b.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0
@@ -23,7 +24,7 @@ compress/rdo_quality_loss=0.0
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
-mipmaps/generate=false
+mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
@@ -37,4 +38,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=1
+detect_3d/compress_to=0

--- a/world/lobby/lobby.tscn
+++ b/world/lobby/lobby.tscn
@@ -1,11 +1,19 @@
-[gd_scene load_steps=3 format=3 uid="uid://d1tkdnfdxej7n"]
+[gd_scene format=3 uid="uid://d1tkdnfdxej7n"]
 
 [ext_resource type="PackedScene" uid="uid://ctsviqutuqw5l" path="res://world/world_base.tscn" id="1_cv4rh"]
+[ext_resource type="PackedScene" uid="uid://dsnep0jd62s78" path="res://items/item_test_1.tscn" id="2_7tkdc"]
+[ext_resource type="PackedScene" uid="uid://ck8obcgulgo8p" path="res://items/item_test_2.tscn" id="3_c06ik"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_cv4rh"]
 
-[node name="Lobby" instance=ExtResource("1_cv4rh")]
+[node name="Lobby" unique_id=1751753838 instance=ExtResource("1_cv4rh")]
 
-[node name="MeshInstance3D2" type="MeshInstance3D" parent="." index="3"]
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="." index="3" unique_id=941313414]
 transform = Transform3D(12.941168, 0, 0, 0, 1.0000005, 0, 0, 0, 11.586485, 0, -0.23607445, 0)
 mesh = SubResource("PlaneMesh_cv4rh")
+
+[node name="ItemTest1" parent="." index="4" unique_id=1566519324 instance=ExtResource("2_7tkdc")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.694867, 0, -5.357811)
+
+[node name="Item" parent="." index="5" unique_id=1674373162 instance=ExtResource("3_c06ik")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.9393296, 0, -6.180363)


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #111 

**Summarize what's new, especially anything not mentioned in the issue.**
Items have been added. I gave them their own dedicated folder since I figure a party game with loads of them will need a dedicated place. Items are inherited scenes, their script inherits from a base `Item` class. This one inherited scene/class combo is an all-in-one for items regardless of if they're held in the player's inventory or floating about in the world. To make a new item, make a new inherited scene from `item_base.tscn`,  

**If there's any remaining work needed, describe that here.**
I left some notes for far in the future once there are playermodels and all that fancy stuff, the items should probably get reparented to a node at the player's hand rather than the player themselves. That's a while off. The Player's script has some edits, once aiming is finished there will need to be an exception to keep the player from using items while aiming.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Start a game, we left the two different test items lying around the lobby. Walk into them and right click to use them. Check the console and see their unique `use()` text be printed once per player.