### PR TITLE
list now shows hostname and player count

### DIFF
--- a/systems/multiplayer.gd
+++ b/systems/multiplayer.gd
@@ -1,7 +1,7 @@
 extends Node
 
 signal new_player(id: int)
-signal found_server(ip: String, name: String)
+signal found_server(ip: String, hostname: String, playerCount: String)
 
 const PORT = 25575
 const MAX_CLIENTS = 3
@@ -16,6 +16,9 @@ var scan_server: UDPServer
 
 var scan_for_servers := true
 var scan_client: PacketPeerUDP
+
+var displayName: String
+
 
 func _ready() -> void:
 	# listen for when clients connect -- runs on both client and server
@@ -32,8 +35,9 @@ func _process_scan_server() -> void:
 		if peer.get_var(0) == SCAN_MSG:
 			Debug.log("sending something to the client.")
 			# TODO: send meaningful data, like our username or something
-			peer.put_var("icanplay")
-
+			var playersOnlineString: String = str(int(multiplayer.get_peers().size())+1) + "/" + str(MAX_CLIENTS+1)
+			peer.put_var([displayName, playersOnlineString])
+			
 # measure the time since we shouted into the void
 var scan_clock := 0.
 func _process_scan_for_servers(delta: float) -> void:
@@ -57,11 +61,14 @@ func _process_scan_for_servers(delta: float) -> void:
 	
 	# also make sure to listen for responses to our shouts
 	while scan_client.get_available_packet_count() > 0:
-		scan_client.get_packet()
+		var s = scan_client.get_var()
 		var server_ip = scan_client.get_packet_ip()
-
+		var foundHostName: String = s[0]
+		var playersOnlineString: String = s[1]
 		Debug.log("scan_client recieved something from %s!" % server_ip)
-		found_server.emit(server_ip)
+
+		
+		found_server.emit(server_ip, foundHostName, playersOnlineString)
 
 func _process(delta: float) -> void:
 	if scan_server: _process_scan_server()

--- a/ui/lobby_browser/lobby_browser.gd
+++ b/ui/lobby_browser/lobby_browser.gd
@@ -13,11 +13,12 @@ func _on_host_button_pressed() -> void:
 	#if name_text.text.length() == 0:
 		#name_text.text = "Player"+str(randi_range(1,999))
 	Multiplayer.create_server()
+	Multiplayer.displayName = %NameInput.text
 	Debug.log("Host Created")
 	get_tree().change_scene_to_file("res://world/lobby/lobby.tscn")
 
 
-func _on_found_server(ip: String) -> void:
+func _on_found_server(ip: String, hostname: String, playerCount: String) -> void:
 	if ip in seen_ips: return
 	seen_ips[ip] = true
 
@@ -27,9 +28,13 @@ func _on_found_server(ip: String) -> void:
 	# there's probably an intended way of doing this, but ¯\_(ツ)_/¯
 	if %ServerInfoParent.get_child_count() % 2 == 0:
 		server_info.self_modulate.a = 1.5 # yes this works, it makes it darker
-
+	
+	server_info.hostname = hostname
+	server_info.playerCount = playerCount
 	server_info.ip = ip
+	
 	server_info.pressed.connect(func() -> void:
+		Multiplayer.displayName = %NameInput.text
 		Multiplayer.join_server(ip)
 		Debug.log("Lobby Joined")
 		get_tree().change_scene_to_file("res://world/lobby/lobby.tscn")

--- a/ui/lobby_browser/lobby_browser.tscn
+++ b/ui/lobby_browser/lobby_browser.tscn
@@ -69,6 +69,7 @@ text = "Display name"
 horizontal_alignment = 1
 
 [node name="NameInput" type="LineEdit" parent="DisplayName" unique_id=2144933206]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 placeholder_text = "Enter name..."

--- a/ui/lobby_browser/server_info.gd
+++ b/ui/lobby_browser/server_info.gd
@@ -8,15 +8,33 @@ signal pressed
 	set(v):
 		ip = v
 		if is_node_ready():
-			_update_ip_label()
+			#_update_ip_label()
+			_update_serverinfo_label(%IPLabel, v)
+@export var hostname: String = "Hostname":
+	set(v):
+		hostname = v
+		if is_node_ready():
+			_update_serverinfo_label(%NameLabel, v)
+		
+@export var playerCount: String = "0/0":
+	set(v):
+		playerCount = v
+		if is_node_ready():
+			_update_serverinfo_label(%CountLabel, v)
 
-func _update_ip_label() -> void:
-	%IPLabel.text = ip
+
+#func _update_ip_label() -> void:
+#	%IPLabel.text = ip
+
+func _update_serverinfo_label(label: Label, newString: String) -> void:
+	label.text = newString
+
 
 func _ready() -> void:
-	_update_ip_label()
-
+	#_update_ip_label()
+	_update_serverinfo_label(%NameLabel, hostname)
+	_update_serverinfo_label(%CountLabel, playerCount)
+	_update_serverinfo_label(%IPLabel, ip)
 
 func _on_join_button_pressed() -> void:
 	pressed.emit()
-

--- a/ui/lobby_browser/server_info.tscn
+++ b/ui/lobby_browser/server_info.tscn
@@ -6,6 +6,7 @@
 custom_minimum_size = Vector2(300, 0)
 script = ExtResource("1_7crmb")
 ip = "192.168.1.2"
+hostname = "- Hostname -"
 
 [node name="MarginContainer" type="MarginContainer" parent="." unique_id=1430094084]
 layout_mode = 2
@@ -17,8 +18,23 @@ theme_override_constants/margin_bottom = 10
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer" unique_id=564481778]
 layout_mode = 2
 
+[node name="NameLabel" type="Label" parent="MarginContainer/HBoxContainer" unique_id=673213215]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Hostname"
+
+[node name="SpaceLabel" type="Label" parent="MarginContainer/HBoxContainer" unique_id=7792534]
+layout_mode = 2
+text = "-"
+
+[node name="CountLabel" type="Label" parent="MarginContainer/HBoxContainer" unique_id=817665762]
+unique_name_in_owner = true
+layout_mode = 2
+text = "0/0"
+
 [node name="IPLabel" type="Label" parent="MarginContainer/HBoxContainer" unique_id=165369734]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 text = "192.168.1.2"
 


### PR DESCRIPTION
yippeeeee

**What issue does this close? For multiple, write a line for each.**
Closes #185 

**Summarize what's new, especially anything not mentioned in the issue.**
The server browser shows the host name and number of players connected to a server! Michael suggested I hide the part of the browser that shows the IP address. I've added a `displayName` variable to the `multiplayer.gd` script that stores the name put onto the join screen whenever you either host or join a game.

**If there's any remaining work needed, describe that here.**
Nothing comes to mind for this issue

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Open the main scene with an additional instance running, host a game, check the other instance and see the entry in the list!