### PR TITLE
Keybind menu

### DIFF
--- a/ui/keybinds/keybind.gd
+++ b/ui/keybinds/keybind.gd
@@ -1,0 +1,22 @@
+extends Control
+
+@export var binding_prototype: HBoxContainer
+
+@onready var vbox: VBoxContainer = $KeybindPanel/VBoxContainer
+
+var keybind_buttons: Dictionary[StringName, HBoxContainer]
+
+func _ready() -> void:
+	for action in InputMap.get_actions():
+		var binding = binding_prototype.duplicate()
+		var binding_label: Label = binding.get_node("Label")
+		var binding_button: Button = binding.get_node("Button")
+		binding_label.text = action
+		binding_button.pressed.connect(_on_keybind_button_pressed.bind(action))
+		binding_button.text = InputMap.action_get_events(action)[0].as_text()
+		keybind_buttons[action] = binding
+		vbox.add_child(binding)
+	binding_prototype.queue_free()
+
+func _on_keybind_button_pressed(keybind: StringName) -> void:
+	pass

--- a/ui/keybinds/keybind.gd
+++ b/ui/keybinds/keybind.gd
@@ -2,21 +2,40 @@ extends Control
 
 @export var binding_prototype: HBoxContainer
 
-@onready var vbox: VBoxContainer = $KeybindPanel/VBoxContainer
+@onready var vbox: VBoxContainer = $KeybindPanel/ScrollContainer/VBoxContainer
 
 var keybind_buttons: Dictionary[StringName, HBoxContainer]
 
+var current_action: StringName
+var current_button: Button
+
 func _ready() -> void:
 	for action in InputMap.get_actions():
+		if action.begins_with("ui_") or action.begins_with("debug_"): continue
 		var binding = binding_prototype.duplicate()
 		var binding_label: Label = binding.get_node("Label")
 		var binding_button: Button = binding.get_node("Button")
 		binding_label.text = action
-		binding_button.pressed.connect(_on_keybind_button_pressed.bind(action))
+		binding_button.pressed.connect(_on_keybind_button_pressed.bind(action, binding_button))
 		binding_button.text = InputMap.action_get_events(action)[0].as_text()
 		keybind_buttons[action] = binding
 		vbox.add_child(binding)
 	binding_prototype.queue_free()
 
-func _on_keybind_button_pressed(keybind: StringName) -> void:
-	pass
+func _on_keybind_button_pressed(keybind: StringName, button: Button) -> void:
+	button.text = "Listening..."
+	current_action = keybind
+	current_button = button
+
+func _input(event: InputEvent) -> void:
+	if current_action and event.is_action_type():
+		InputMap.action_erase_events(current_action)
+		InputMap.action_add_event(current_action, event)
+		current_action = ""
+		current_button.text = event.as_text()
+		current_button.release_focus()
+		current_button = null
+	#else:  # Useful for checking if an input is bound to an action
+		#for action in keybind_buttons.keys():
+			#if (event.is_action(action)):
+				#print("%s binds to %s!" % [event.as_text(), action])

--- a/ui/keybinds/keybind.gd.uid
+++ b/ui/keybinds/keybind.gd.uid
@@ -1,0 +1,1 @@
+uid://87m7v2osfe3g

--- a/ui/keybinds/keybind_menu.tscn
+++ b/ui/keybinds/keybind_menu.tscn
@@ -27,16 +27,23 @@ patch_margin_top = 15
 patch_margin_right = 15
 patch_margin_bottom = 15
 
-[node name="VBoxContainer" type="VBoxContainer" parent="KeybindPanel" unique_id=243079951]
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -50.0
-offset_top = -72.5
-offset_right = 50.0
-offset_bottom = 72.5
-grow_horizontal = 2
-grow_vertical = 2
+[node name="ScrollContainer" type="ScrollContainer" parent="KeybindPanel" unique_id=640497245]
+layout_mode = 0
+offset_left = 37.0
+offset_top = 29.0
+offset_right = 340.0
+offset_bottom = 480.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="KeybindPanel/ScrollContainer" unique_id=243079951]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="KeybindPanel/ScrollContainer/VBoxContainer" unique_id=1438515188]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="KeybindPanel/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=1161519030]
+layout_mode = 2
+text = "Control whatefver it is"
+
+[node name="Button" type="Button" parent="KeybindPanel/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=1555108729]
+layout_mode = 2
+text = "Key that it is"

--- a/ui/keybinds/keybind_menu.tscn
+++ b/ui/keybinds/keybind_menu.tscn
@@ -1,6 +1,6 @@
 [gd_scene format=3 uid="uid://vpljqilqhkbb"]
 
-[ext_resource type="Script" uid="uid://bp1ga0y2284ok" path="res://ui/options/options_menu.gd" id="1_kckta"]
+[ext_resource type="Script" uid="uid://87m7v2osfe3g" path="res://ui/keybinds/keybind.gd" id="1_s866l"]
 [ext_resource type="Texture2D" uid="uid://c4bcw1f4x3ex5" path="res://temp/temp_art/icon.svg" id="2_lngt1"]
 
 [node name="KeybindMenu" type="Control" unique_id=1087068024]
@@ -10,7 +10,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_kckta")
+script = ExtResource("1_s866l")
 
 [node name="KeybindPanel" type="NinePatchRect" parent="." unique_id=810038643]
 layout_mode = 1

--- a/ui/keybinds/keybind_menu.tscn
+++ b/ui/keybinds/keybind_menu.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://87m7v2osfe3g" path="res://ui/keybinds/keybind.gd" id="1_s866l"]
 [ext_resource type="Texture2D" uid="uid://c4bcw1f4x3ex5" path="res://temp/temp_art/icon.svg" id="2_lngt1"]
 
-[node name="KeybindMenu" type="Control" unique_id=1087068024]
+[node name="KeybindMenu" type="Control" unique_id=1087068024 node_paths=PackedStringArray("binding_prototype")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -11,6 +11,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_s866l")
+binding_prototype = NodePath("KeybindPanel/ScrollContainer/VBoxContainer/HBoxContainer")
 
 [node name="KeybindPanel" type="NinePatchRect" parent="." unique_id=810038643]
 layout_mode = 1

--- a/ui/keybinds/keybind_menu.tscn
+++ b/ui/keybinds/keybind_menu.tscn
@@ -1,0 +1,42 @@
+[gd_scene format=3 uid="uid://vpljqilqhkbb"]
+
+[ext_resource type="Script" uid="uid://bp1ga0y2284ok" path="res://ui/options/options_menu.gd" id="1_kckta"]
+[ext_resource type="Texture2D" uid="uid://c4bcw1f4x3ex5" path="res://temp/temp_art/icon.svg" id="2_lngt1"]
+
+[node name="KeybindMenu" type="Control" unique_id=1087068024]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_kckta")
+
+[node name="KeybindPanel" type="NinePatchRect" parent="." unique_id=810038643]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.33333334
+anchor_top = 0.09876543
+anchor_right = 0.6666667
+anchor_bottom = 0.8888889
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("2_lngt1")
+patch_margin_left = 15
+patch_margin_top = 15
+patch_margin_right = 15
+patch_margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="KeybindPanel" unique_id=243079951]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -72.5
+offset_right = 50.0
+offset_bottom = 72.5
+grow_horizontal = 2
+grow_vertical = 2


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #195 - Keybind Menu

**Summarize what's new, especially anything not mentioned in the issue.**
There is now a keybind menu that pulls actions from `InputMap` and creates label-button pairs within a scroll container. The labels display the possible actions, and the buttons display the current binding. Clicking the button will listen for the next input and rebind the action to that new input.

**If there's any remaining work needed, describe that here.**
The actions in the keybind menu are still in `snake_case`, so they could be modified to appear more user-friendly.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
The scene `ui/keybinds/keybind_menu.tscn` can be run, and the user can click the buttons to rebind the controls. There is commented code in the `_input()` method that can optionally print the action associated with the input to the console.