### PR TITLE
multiplayer desync bug

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -38,7 +38,10 @@ func _ready() -> void:
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 
 func _process(delta: float) -> void:
+	# don't process input if ragdolled
 	if is_ragdolled: return
+	# don't process input if this is not our player
+	if not is_multiplayer_authority(): return
 	
 	var input := Input.get_vector("move_left", "move_right", "move_up", "move_down")
 	var movement_dir : Vector2 = input.rotated(-deg_to_rad(camera_yaw))

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://bx8rb13al7o7e" path="res://player/player.gd" id="1_onrkg"]
 [ext_resource type="Script" uid="uid://b0w3b5ncyaqf2" path="res://player/player_mesh.gd" id="2_pmesh"]
+[ext_resource type="Script" uid="uid://dm41gwejdfgy" path="res://player/player_id.gd" id="5_g6k8r"]
 [ext_resource type="PackedScene" uid="uid://c0h4ahbau2lur" path="res://art/3d-assets/Bean.glb" id="5_qjkh3"]
 [ext_resource type="Script" uid="uid://bqpwk0pccci1t" path="res://player/ragdoll.gd" id="6_boad6"]
 
@@ -341,12 +342,12 @@ shape = SubResource("CapsuleShape3D_boad6")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
 
 [node name="Physical Bone Head" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=1544910262]
-transform = Transform3D(0.83986056, 0.0030375444, 0.0030055954, -0.00026133226, 0.62613535, -0.55976635, -0.0042652064, 0.5597582, 0.6261282, -0.0005058444, 1.387533, 0.012263814)
+transform = Transform3D(0.83986056, 0.0030375444, 0.0030055956, -0.00026133226, 0.62613535, -0.55976635, -0.0042652064, 0.5597582, 0.6261282, -0.0005058444, 1.387533, 0.012263814)
 collision_layer = 8
 collision_mask = 9
 joint_type = 5
 joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0007138621, -0.09940035, 0.06928196)
-body_offset = Transform3D(0.8398607, 0.003037406, 0.0030054585, -2.910383e-11, 0.5907305, -0.59701025, -0.004273008, 0.59700274, 0.5907231, -0.0005058495, 0.10008085, 0.018418878)
+body_offset = Transform3D(0.8398607, 0.003037406, 0.0030054583, -2.910383e-11, 0.5907305, -0.59701025, -0.004273008, 0.59700274, 0.5907231, -0.0005058495, 0.10008085, 0.018418878)
 bone_name = "Head"
 joint_constraints/x/linear_limit_enabled = true
 joint_constraints/x/linear_limit_upper = 0.0
@@ -418,12 +419,12 @@ shape = SubResource("CapsuleShape3D_rgyib")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
 
 [node name="Physical Bone Shoulder L" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=327660131]
-transform = Transform3D(-0.19679055, 0.023097986, -0.81616414, -0.8157743, 0.029603265, 0.19753435, 0.0342002, 0.83903164, 0.015498922, 0.24794918, 1.0807664, 0.0026379798)
+transform = Transform3D(-0.19679055, 0.023097986, -0.8161641, -0.8157743, 0.029603265, 0.19753434, 0.0342002, 0.83903164, 0.01549892, 0.24794918, 1.0807664, 0.0026379798)
 collision_layer = 8
 collision_mask = 9
 joint_type = 5
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0037597502, -0.0026087642, 0.30441076)
-body_offset = Transform3D(0.8398712, 2.30968e-07, -1.28261745e-05, -1.2830831e-05, 1.3327226e-06, -0.8398712, -2.1234155e-07, 0.8398712, 1.325272e-06, -0.003153801, 0.2556659, 0.0021906234)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.003759745, -0.0026087645, 0.30441076)
+body_offset = Transform3D(0.8398712, 2.30968e-07, -1.2811157e-05, -1.2830831e-05, 1.3327226e-06, -0.8398713, -2.1234155e-07, 0.8398712, 1.325272e-06, -0.003153801, 0.2556659, 0.0021906234)
 bone_name = "Shoulder L"
 joint_constraints/x/linear_limit_enabled = true
 joint_constraints/x/linear_limit_upper = 0.0
@@ -495,12 +496,12 @@ shape = SubResource("CapsuleShape3D_hg6s5")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
 
 [node name="Physical Bone UpperArm L" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=1409918889]
-transform = Transform3D(-0.7105672, 0.09883569, -0.43670323, -0.44561848, -0.076308556, 0.707803, 0.043616205, 0.83053744, 0.11700049, 0.3554602, 0.9889976, 0.0018311556)
+transform = Transform3D(-0.7105672, 0.098835684, -0.4367032, -0.44561848, -0.07630856, 0.707803, 0.043616205, 0.83053744, 0.117000505, 0.3554602, 0.9889976, 0.0018311556)
 collision_layer = 8
 collision_mask = 9
 joint_type = 5
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.026203815, -0.021725034, 0.12864749)
-body_offset = Transform3D(0.83987117, -5.5879354e-08, -6.6589564e-08, -1.2200326e-07, -2.9802322e-08, -0.8398711, 6.7055225e-08, 0.8398714, 7.450581e-09, -0.022007823, 0.10804731, 0.01824623)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.026203811, -0.021725029, 0.12864749)
+body_offset = Transform3D(0.83987117, -6.7055225e-08, -3.7718564e-08, -1.2200326e-07, -2.9802322e-08, -0.8398711, 6.7055225e-08, 0.83987147, -7.450581e-09, -0.022007823, 0.10804731, 0.01824623)
 bone_name = "UpperArm L"
 joint_constraints/x/linear_limit_enabled = true
 joint_constraints/x/linear_limit_upper = 0.0
@@ -572,12 +573,12 @@ shape = SubResource("CapsuleShape3D_8t03j")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
 
 [node name="Physical Bone Forearm L" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=231707070]
-transform = Transform3D(-0.6881668, -0.06075885, -0.47761783, -0.48003107, 0.15088181, 0.6724498, 0.037156373, 0.8239702, -0.15835519, 0.43577182, 0.8655872, 0.016498443)
+transform = Transform3D(-0.68816674, -0.060758844, -0.47761777, -0.48003104, 0.15088183, 0.6724498, 0.03715637, 0.8239702, -0.15835519, 0.43577182, 0.8655872, 0.016498443)
 collision_layer = 8
 collision_mask = 9
 joint_type = 5
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.024746552, -0.03659236, 0.08888768)
-body_offset = Transform3D(0.8398713, -3.7252903e-09, 4.982576e-07, 4.763715e-07, 0, -0.8398713, 4.4703484e-08, 0.8398714, -8.940697e-08, -0.02078396, 0.07465419, 0.030732885)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.024746541, -0.03659236, 0.08888768)
+body_offset = Transform3D(0.83987135, 7.450581e-09, 5.578622e-07, 4.7683716e-07, 0, -0.8398713, 4.0978193e-08, 0.8398714, -7.4505806e-08, -0.02078396, 0.07465419, 0.030732885)
 bone_name = "Forearm L"
 joint_constraints/x/linear_limit_enabled = true
 joint_constraints/x/linear_limit_upper = 0.0
@@ -649,12 +650,12 @@ shape = SubResource("CapsuleShape3D_2ieo8")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
 
 [node name="Physical Bone Shoulder R" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=502267599]
-transform = Transform3D(-0.19677807, -0.023096766, 0.8161672, 0.81577736, 0.029603783, 0.19752184, -0.03420018, 0.8390316, 0.01549814, -0.23294365, 1.0476424, 0.0026378236)
+transform = Transform3D(-0.19677807, -0.023096766, 0.8161672, 0.81577736, 0.029603785, 0.19752184, -0.03420018, 0.83903164, 0.01549814, -0.23294365, 1.0476424, 0.0026378236)
 collision_layer = 8
 collision_mask = 9
 joint_type = 5
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.038738966, -0.0007266097, 0.29632407)
-body_offset = Transform3D(0.8398712, -2.6077032e-08, -2.4057226e-07, -1.0279473e-07, -1.8626451e-09, -0.8398713, -3.7252903e-09, 0.83987147, 1.8626451e-09, -0.032535672, 0.24887407, 0.00061025843)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.038738966, -0.0007266097, 0.29632404)
+body_offset = Transform3D(0.8398712, -2.9802322e-08, -2.4057226e-07, -1.0279473e-07, -9.313226e-10, -0.8398713, -3.7252903e-09, 0.8398714, 1.8626451e-09, -0.032535672, 0.24887407, 0.00061025843)
 bone_name = "Shoulder R"
 joint_constraints/x/linear_limit_enabled = true
 joint_constraints/x/linear_limit_upper = 0.0
@@ -726,12 +727,12 @@ shape = SubResource("CapsuleShape3D_ebec5")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
 
 [node name="Physical Bone UpperArm R" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=302923642]
-transform = Transform3D(-0.7105671, -0.0988355, 0.43670338, 0.44561863, -0.076308645, 0.70780295, -0.04361598, 0.83053744, 0.117000476, -0.37434927, 0.90794826, -0.013410024)
+transform = Transform3D(-0.7105671, -0.0988355, 0.43670338, 0.44561863, -0.07630864, 0.70780295, -0.04361598, 0.83053744, 0.11700047, -0.37434927, 0.90794826, -0.013410024)
 collision_layer = 8
 collision_mask = 9
 joint_type = 5
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.005027963, -0.015194283, 0.22419715)
-body_offset = Transform3D(0.8398713, -1.2665987e-07, -4.125759e-07, -1.4528632e-07, -9.685755e-08, -0.8398713, 1.5646219e-07, 0.8398714, -6.7055225e-08, -0.0042227507, 0.18829674, 0.012761258)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.005027963, -0.015194287, 0.22419715)
+body_offset = Transform3D(0.8398713, -1.3038516e-07, -4.1304156e-07, -1.4528632e-07, -9.685755e-08, -0.8398713, 1.5646219e-07, 0.8398714, -5.2154064e-08, -0.0042227507, 0.18829674, 0.012761258)
 bone_name = "UpperArm R"
 joint_constraints/x/linear_limit_enabled = true
 joint_constraints/x/linear_limit_upper = 0.0
@@ -803,12 +804,12 @@ shape = SubResource("CapsuleShape3D_yllr7")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
 
 [node name="Physical Bone Forearm R" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=1656279309]
-transform = Transform3D(-0.68816674, 0.060759056, 0.47761792, 0.4800312, 0.1508822, 0.6724497, -0.03715644, 0.82397014, -0.15835564, -0.43335894, 0.8298867, -0.016829541)
+transform = Transform3D(-0.68816674, 0.060759064, 0.47761792, 0.4800312, 0.1508822, 0.6724497, -0.03715644, 0.82397014, -0.15835564, -0.43335894, 0.8298867, -0.016829541)
 collision_layer = 8
 collision_mask = 9
 joint_type = 5
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0001469558, 0.009767206, 0.11380574)
-body_offset = Transform3D(0.83987135, 2.2351742e-08, -8.9779496e-07, -6.360933e-07, -4.917383e-07, -0.83987135, -8.195639e-08, 0.8398715, -5.662441e-07, -0.00012332201, 0.09558219, -0.008203134)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00014695576, 0.009767206, 0.11380574)
+body_offset = Transform3D(0.83987135, 2.6077032e-08, -8.9779496e-07, -6.360933e-07, -4.917383e-07, -0.83987135, -8.195639e-08, 0.8398715, -5.662441e-07, -0.00012332201, 0.09558219, -0.008203134)
 bone_name = "Forearm R"
 joint_constraints/x/linear_limit_enabled = true
 joint_constraints/x/linear_limit_upper = 0.0
@@ -1186,5 +1187,13 @@ joint_constraints/z/angular_equilibrium_point = 0.0
 transform = Transform3D(1.0000011, 2.9802322e-08, -1.2665987e-07, 8.195639e-08, -3.9115548e-08, 1, -2.9802322e-07, -1.0000014, 3.7252903e-09, 0, 0, 0)
 shape = SubResource("CapsuleShape3D_e7oew")
 debug_color = Color(0.94688505, 4.042983e-06, 0.58569956, 0.42)
+
+[node name="PlayerId" type="Label3D" parent="." unique_id=1279931641]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2423403, 0)
+billboard = 2
+text = "1234"
+font_size = 47
+outline_size = 25
+script = ExtResource("5_g6k8r")
 
 [editable path="Body"]

--- a/player/player_id.gd
+++ b/player/player_id.gd
@@ -1,0 +1,4 @@
+extends Label3D
+
+func _process(_delta: float) -> void:
+	text = str(get_multiplayer_authority())

--- a/player/player_id.gd.uid
+++ b/player/player_id.gd.uid
@@ -1,0 +1,1 @@
+uid://dm41gwejdfgy

--- a/world/world_base.gd
+++ b/world/world_base.gd
@@ -4,27 +4,30 @@ extends Node3D
 @export var player : PackedScene
 
 func _ready() -> void:
-	
+	Multiplayer.new_player.connect(on_player_join)
 	if multiplayer.is_server():
-		Multiplayer.new_player.connect(on_player_join)
 		Debug.log("Creating player...")
-		spawn_player(1)
+		spawn_player.rpc(1, $Players.get_safe_spawn_point())
 		$CanvasLayer/VBoxContainer/Label.text = "Server"
 	else:
 		$CanvasLayer/VBoxContainer/Label.text = "Client"
-	pass
 
 func on_player_join(id : int) -> void:
-	spawn_player(id)
+	if not multiplayer.is_server():
+		return
+	
+	
+	for player_id in Multiplayer.player_list:
+		if player_id != id:
+			spawn_player.rpc_id(id,player_id,Vector3.ZERO)
+	spawn_player.rpc(id,Vector3.ZERO)
+	
 
-func spawn_player(id: int) -> void:
+@rpc("reliable", "call_local")
+func spawn_player(id: int, pos: Vector3) -> void:
 	Debug.log("Creating player of id ",id)
 	var new_player: Player = player.instantiate()
-	# WARNING you HAVE to set position before adding child or else you DIE.
-	new_player.position = $Players.get_safe_spawn_point()
-	$Players.add_child(new_player,true)
+	new_player.set_multiplayer_authority(id)
 	
-	new_player.set_authority.rpc(id)
-	#new_player.update_camera.rpc_id(id)`
-	
-	Debug.log(new_player.position)
+	add_child(new_player)
+	new_player.position = pos

--- a/world/world_base.gd
+++ b/world/world_base.gd
@@ -13,21 +13,23 @@ func _ready() -> void:
 		$CanvasLayer/VBoxContainer/Label.text = "Client"
 
 func on_player_join(id : int) -> void:
+	# this function only runs on the server
 	if not multiplayer.is_server():
 		return
 	
+	for child in get_children():
+		if child is Player:
+			var p: Player = child
+			spawn_player.rpc_id(id, p.get_multiplayer_authority(), p.position)
 	
-	for player_id in Multiplayer.player_list:
-		if player_id != id:
-			spawn_player.rpc_id(id,player_id,Vector3.ZERO)
-	spawn_player.rpc(id,Vector3.ZERO)
+	spawn_player.rpc(id,$Players.get_safe_spawn_point())
 	
 
 @rpc("reliable", "call_local")
 func spawn_player(id: int, pos: Vector3) -> void:
 	Debug.log("Creating player of id ",id)
 	var new_player: Player = player.instantiate()
-	new_player.set_multiplayer_authority(id)
 	
-	add_child(new_player)
 	new_player.position = pos
+	add_child(new_player)
+	new_player.set_authority(id) # we don't need to use RPC here since this function call is RPC'd

--- a/world/world_base.tscn
+++ b/world/world_base.tscn
@@ -22,10 +22,6 @@ text = "Hello"
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="." unique_id=1620714622]
 transform = Transform3D(1, 0, 0, 0, 0.5577596, 0.83000255, 0, -0.83000255, 0.5577596, 0, 11.385282, 8.448111)
 
-[node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="." unique_id=1699929159]
-_spawnable_scenes = PackedStringArray("uid://bffxe171rcnea")
-spawn_path = NodePath("../Players")
-
 [node name="Players" type="Node3D" parent="." unique_id=1891362098 groups=["Spawnpoints"]]
 script = ExtResource("3_3xj4d")
 


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #236

**Summarize what's new, especially anything not mentioned in the issue.**
Fixes two desync bugs:
1. The player could control other players (purely visual). This is fixed by guarding `Player._process`.
2. Players spawned in do not have the correct authority. I reverted the commit that gave us the MultiplayerSpawner node and went back to spawning stuff manually.

I also added a debug label displaying the multiplayer authority of a player.

**If there's any remaining work needed, describe that here.**
This code will probably need to be updated for the starting game sequence.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Test that the game works with more than two people. Everything should be synced up correctly. When any player moves, it's represented on other screens.