### PR TITLE
aiming fishing rod

### DIFF
--- a/player/aiming.gd
+++ b/player/aiming.gd
@@ -1,0 +1,47 @@
+extends Node3D
+
+var player: Player
+
+## How far away from the player the player can aim.
+@export var max_aim_distance := 5.
+
+var _aim_pos := Vector2.ZERO
+
+func _ready() -> void:
+	assert(get_parent() is Player)
+	player = get_parent()
+	%AimIndicator.hide()
+
+func _process(_delta: float) -> void:
+	%AimRayCast.position.x = _aim_pos.x
+	%AimRayCast.position.z = _aim_pos.y
+
+	%AimRayCast.force_raycast_update()
+	if %AimRayCast.is_colliding():
+		%AimIndicator.position = to_local(%AimRayCast.get_collision_point())
+
+func _input(event: InputEvent) -> void:
+	if not player.is_aiming: return
+
+	if event is InputEventMouseMotion and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
+		var dv: Vector2 = event.relative
+		dv *= 0.075
+		dv *= Options.mouse_sensitivity
+		dv = dv.rotated(deg_to_rad(-player.camera_yaw))
+
+		_aim_pos.x += dv.x
+		_aim_pos.y += dv.y
+		_aim_pos = _aim_pos.limit_length(max_aim_distance)
+
+func start_aiming() -> void:
+	player.is_aiming = true
+	%AimIndicator.show()
+	_aim_pos = Vector2.ZERO
+
+func stop_aiming() -> void:
+	player.is_aiming = false
+	%AimIndicator.hide()
+
+## Get where the player is aiming at in global coordinates
+func get_aim_pos() -> Vector3:
+	return %AimIndicator.global_position

--- a/player/aiming.gd.uid
+++ b/player/aiming.gd.uid
@@ -1,0 +1,1 @@
+uid://c3ahl7fgjexil

--- a/player/player.gd
+++ b/player/player.gd
@@ -13,6 +13,7 @@ const GRAVITY := 30.
 
 var last_pos : Vector3 = Vector3.ZERO
 var held_item: Item
+var is_aiming := false
 
 
 @onready var camera_mount : Node3D = $CameraMount
@@ -39,7 +40,9 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	# don't process input if ragdolled
-	if is_ragdolled: return
+	if is_ragdolled: 
+		%Aiming.stop_aiming()
+		return
 	# don't process input if this is not our player
 	if not is_multiplayer_authority(): return
 	
@@ -56,6 +59,12 @@ func _process(delta: float) -> void:
 
 	if input != Vector2.ZERO:
 		$Body.turn_towards(movement_dir.rotated(-PI/2), delta)
+	
+	if Input.is_action_just_pressed("cast_rod"):
+		%Aiming.start_aiming()
+	if Input.is_action_just_released("cast_rod"):
+		%Aiming.stop_aiming()
+		Debug.log("TODO: fire fishing rod at global position ", %Aiming.get_aim_pos())
 
 func _physics_process(_delta: float) -> void:
 	if is_multiplayer_authority():
@@ -91,19 +100,21 @@ func update_camera() -> void:
 
 func _input(event: InputEvent) -> void:
 	if not is_multiplayer_authority(): return
-	if event is InputEventMouseMotion and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
-		camera_yaw += -event.relative.x * Options.mouse_sensitivity
-		$CameraMount.rotation.y = deg_to_rad(camera_yaw)
+
 	if event.is_action_pressed("scoreboard"):
 		pass
 	if event.is_action_pressed("test1"):
 		ragdoll_phys.ragdoll(5)
-		pass
 	if event.is_action_pressed("print_players"):
 		Debug.print_players()
-	if event.is_action_pressed("use_item"):
-		#TODO: Don't let this happen if the player is aiming.
-		use_held_item.rpc()
+	
+	if not is_aiming:
+		if event.is_action_pressed("use_item"):
+			use_held_item.rpc()
+		if event is InputEventMouseMotion and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
+			camera_yaw += -event.relative.x * Options.mouse_sensitivity
+			$CameraMount.rotation.y = deg_to_rad(camera_yaw)
+
 
 @rpc("unreliable_ordered")
 func sync_velocity(vel: Vector3) -> void:

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Script" uid="uid://dm41gwejdfgy" path="res://player/player_id.gd" id="5_g6k8r"]
 [ext_resource type="PackedScene" uid="uid://c0h4ahbau2lur" path="res://art/3d-assets/Bean.glb" id="5_qjkh3"]
 [ext_resource type="Script" uid="uid://bqpwk0pccci1t" path="res://player/ragdoll.gd" id="6_boad6"]
+[ext_resource type="Script" uid="uid://c3ahl7fgjexil" path="res://player/aiming.gd" id="6_g6k8r"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_rkbax"]
 
@@ -77,6 +78,8 @@ height = 0.16894531
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_e7oew"]
 radius = 0.15673828
 height = 0.33034313
+
+[sub_resource type="SphereMesh" id="SphereMesh_boad6"]
 
 [node name="Player" type="CharacterBody3D" unique_id=1653185810 groups=["Player"]]
 collision_layer = 2
@@ -1195,5 +1198,18 @@ text = "1234"
 font_size = 47
 outline_size = 25
 script = ExtResource("5_g6k8r")
+
+[node name="Aiming" type="Node3D" parent="." unique_id=1376626479]
+unique_name_in_owner = true
+script = ExtResource("6_g6k8r")
+
+[node name="AimIndicator" type="MeshInstance3D" parent="Aiming" unique_id=286163285]
+unique_name_in_owner = true
+mesh = SubResource("SphereMesh_boad6")
+
+[node name="AimRayCast" type="RayCast3D" parent="Aiming" unique_id=1055354609]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 0)
+target_position = Vector3(0, -10, 0)
 
 [editable path="Body"]


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #115

**Summarize what's new, especially anything not mentioned in the issue.**
Adds in the `Aiming` node to player. When calling `Aiming.start_aiming()`, the player will begin aiming and when calling `Aiming.stop_aiming()`, the player will stop aiming. While aiming, the player cannot control the camera and mouse movement will affect an aiming sphere indicator. At any time, you can call `Aiming.get_aim_pos()` to get where the player is aiming in global coordinates.

Aiming automatically takes into account the height of terrain, using a raycast every frame to get where the aim indicator should be.

**If there's any remaining work needed, describe that here.**
The player will probably need a state machine to more accurately map what is shown in the GDD.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Hop into the lobby or heightmap test. Press left mouse button to aim, and release with left mouse button to stop aiming. After you've stopped aiming, there will be a message that pops up on screen with the location of where you aimed.