### PR TITLE
Ragdoll Fixes

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -7,7 +7,9 @@ const FOOTSTEP_MIN_HORIZONTAL_SPEED := 0.1
 # Ragdoll
 @export_group("Scenes")
 @export var ragdoll : PackedScene
-@export var is_ragdolled := false
+var is_ragdolled := false
+@onready var ragdoll_phys : PhysicalBoneSimulator3D = $Body/Armature/Skeleton3D/Bones
+var can_exit_ragdoll := false
 
 @export_category("Variables")
 @export var speed := 10.
@@ -50,9 +52,6 @@ var _landing_time_since_last := 0.0
 var _jump_event_id: int = 0
 var _last_played_jump_event_id: int = -1
 
-# Ragdoll
-@onready var ragdoll_phys : PhysicalBoneSimulator3D = $Body/Armature/Skeleton3D/Bones
-
 # Item Variables
 var wearing_helmet := false
 
@@ -78,8 +77,11 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	# don't process input if ragdolled
-	if is_ragdolled: 
+	if is_ragdolled:
 		%Aiming.stop_aiming()
+		velocity = Vector3.ZERO
+		if (can_exit_ragdoll or ragdoll_phys.is_moving()) and Input.is_action_just_pressed("jump"):
+			ragdoll_phys.end_ragdoll()
 		return
 	# don't process input if this is not our player
 	if not is_multiplayer_authority(): return
@@ -150,7 +152,7 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("scoreboard"):
 		pass
 	if event.is_action_pressed("test1"):
-		ragdoll_phys.ragdoll(5)
+		ragdoll_phys.ragdoll(10, true)
 	if event.is_action_pressed("print_players"):
 		Debug.print_players()
 	

--- a/player/ragdoll.gd
+++ b/player/ragdoll.gd
@@ -2,6 +2,8 @@ extends PhysicalBoneSimulator3D
 
 var player: Player
 var skeleton: Skeleton3D
+# This is for if the item prevents getting up from not moving
+var check_movement_toggle = true
 
 # Syncs player entity and skeleton of the player
 # Deferred due to needing to wait for player_items to have been initialized
@@ -9,20 +11,31 @@ func _ready():
 	player = $"../../../.."
 	skeleton = get_parent()
 
+var timer := 0.0
+var next_check := 0.0
+func _process(delta: float) -> void:
+	if not player.is_ragdolled or not check_movement_toggle: return
+	if timer >= next_check:
+		next_check = timer + 1
+		check_movement()
+	else:
+		timer = timer + delta
+
 # Call this function
-func ragdoll(duration: float):
-	if multiplayer.is_server(): start_ragdoll.rpc(duration)
-	else: ragdoll_request.rpc_id(1, duration)
+# Second variable is optional, set it to true to force players to wait the entire duration
+func ragdoll(duration: float, prevent_move_check: bool = false):
+	if multiplayer.is_server(): start_ragdoll.rpc(duration, prevent_move_check)
+	else: ragdoll_request.rpc_id(1, duration, prevent_move_check)
 
 # Has the Host call the ragdoll so everyone recieves it.
 @rpc("any_peer", "reliable")
-func ragdoll_request(duration: float):
-	if multiplayer.is_server(): start_ragdoll.rpc(duration)
+func ragdoll_request(duration: float, prevent_move_check: bool):
+	if multiplayer.is_server(): start_ragdoll.rpc(duration, prevent_move_check)
 
 # Checks if the player's ragdoll is on the ground.
 func is_ragdoll_on_floor() -> bool:
 	var pelvis_pos = player.ragdoll_phys.get_node("Physical Bone Pelvis").global_position
-	var query = PhysicsRayQueryParameters3D.create(pelvis_pos, pelvis_pos + Vector3(0, -10, 0))
+	var query = PhysicsRayQueryParameters3D.create(pelvis_pos, pelvis_pos + Vector3(0, -15, 0))
 	query.collision_mask = 1
 	query.exclude = [player.get_rid()]
 	var result = get_world_3d().direct_space_state.intersect_ray(query)
@@ -34,46 +47,69 @@ func is_ragdoll_on_floor() -> bool:
 		return false
 
 # This validates if the player is on valid ground/has valid ground beneath them
-func is_valid_ground() -> bool:
+func is_valid_ground() -> Array:
 	var pelvis_pos = player.ragdoll_phys.get_node("Physical Bone Pelvis").global_position
 	var query = PhysicsRayQueryParameters3D.create(pelvis_pos, pelvis_pos + Vector3(0, -25, 0))
 	query.collision_mask = 1
 	query.exclude = [player.get_rid()]
 	var collision = get_world_3d().direct_space_state.intersect_ray(query)
-	return collision.has("position")
+	if collision.has("position"):
+		return [true, collision.position]
+	else:
+		return [false, Vector3.ZERO]
 
 # Performs the actual ragdolling
 @rpc("any_peer", "call_local", "reliable")
-func start_ragdoll(duration: float):
+func start_ragdoll(duration: float, prevent_move_check: bool):
 	if not multiplayer.is_server() and multiplayer.get_remote_sender_id() != 1:
 		Debug.log("Not the server, and not the client that triggered this, ignoring")
 		return
 	if player.is_ragdolled: return
 	if !can_ragdoll(): return
+	if prevent_move_check:
+		check_movement_toggle = false
 
 	player.is_ragdolled = true
 	physical_bones_start_simulation()
 
 	await get_tree().create_timer(duration).timeout
-	end_ragdoll()
+	if player.is_ragdolled:
+		player.can_exit_ragdoll = true
+		Debug.log("Player can Unragdoll")
 
 # This is seperate so if something else happens, this fucntion can be called to end the ragdoll state if the start_ragdoll script breaks after ragdolling
-func end_ragdoll() -> void:
+# Call this to end ragdoll
+func end_ragdoll():
+	if multiplayer.is_server(): confirm_end_ragdoll.rpc()
+	else: end_ragdoll_request.rpc_id(1)
+
+# Has the Host call the ragdoll so everyone recieves it.
+@rpc("any_peer", "reliable")
+func end_ragdoll_request():
+	if multiplayer.is_server(): confirm_end_ragdoll.rpc()
+
+@rpc("any_peer", "call_local", "reliable")
+func confirm_end_ragdoll():
 	# If ragdoll is on the floor(Or close Enough) it will spawn the player at the ragdolls position.
 	# If ragdoll isn't on valid ground(Clipped through map)
-	if is_ragdoll_on_floor():
-		player.global_position = self.get_node("Physical Bone Pelvis").global_position + Vector3(0, 5, 0)
-	elif not is_valid_ground():
+	if is_valid_ground():
+		player.global_position = self.get_node("Physical Bone Pelvis").global_position + Vector3(0, 1.5, 0)
+	elif not is_valid_ground()[0]:
 		var player_spawnpoints = get_tree().root.get_node("World/Players")
 		if player_spawnpoints:
 			player.global_position = player_spawnpoints.get_safe_spawn_point()
 		else:
 			Debug.log_err("No spawner found in scene, and player ragdolled onto invalid ground. Player will be teleported to world origin.")
-			player.global_position = Vector3.ZERO + Vector3(0, 5, 0)
+			player.global_position = Vector3.ZERO + Vector3(0, 1.5, 0)
 
 	physical_bones_stop_simulation()
 	player.is_ragdolled = false
 	skeleton.reset_bone_poses()
+
+	#Reset values
+	stopped_moving = false
+	player.can_exit_ragdoll = false 
+	check_movement_toggle = true
 
 func can_ragdoll() -> bool:
 	if player.wearing_helmet:
@@ -81,3 +117,18 @@ func can_ragdoll() -> bool:
 		player.wearing_helmet = false
 		return false
 	return true
+
+var stopped_moving := false
+var last_pos := Vector3.ZERO
+# Used for determining if the player's ragdoll has stopped moving
+func check_movement() -> void:
+	if stopped_moving or not player.is_ragdolled: return
+	var pelv_pos = player.ragdoll_phys.get_node("Physical Bone Pelvis").global_position
+
+	if last_pos.is_equal_approx(pelv_pos):
+		stopped_moving = true
+	else:
+		last_pos = pelv_pos
+
+# Call this to check if the ragdoll is still moving enough
+func is_moving() -> bool: return check_movement_toggle and stopped_moving

--- a/player/ragdoll.gd
+++ b/player/ragdoll.gd
@@ -47,6 +47,10 @@ func is_ragdoll_on_floor() -> bool:
 		return false
 
 # This validates if the player is on valid ground/has valid ground beneath them
+# Returns an array where:
+#     The first element is true|false for the ground position above the player
+#     The second element is where the ground is below the player, or Vector3.ZERO 
+#     if there's no ground below the player
 func is_valid_ground() -> Array:
 	var pelvis_pos = player.ragdoll_phys.get_node("Physical Bone Pelvis").global_position
 	var query = PhysicsRayQueryParameters3D.create(pelvis_pos, pelvis_pos + Vector3(0, -25, 0))


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes None

**Summarize what's new, especially anything not mentioned in the issue.**
- Updated to the specifications of the GDD document. 
- Now requires spacebar to exit the ragdoll state, although if the player is sitting still they will be able to unragdoll themselves
- Added second variable to ragdoll()
It now takes a boolean after the duration, this will prevent the player from unragdolling until the duration has fully passed
- updated so that there is now a seperate callable end ragdoll function. To call use "end_ragdoll()"
- FIxed issue where the player's actual body would still slide away into the void. Now just stops all player momentum (Doesn't affect ragdoll)

**If there's any remaining work needed, describe that here.**
N/A

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Clicking enter. 