### PR TITLE
hide held items

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -287,6 +287,8 @@ func pick_up_item(item: Item) -> void:
 	held_item = item
 	held_item.is_held = true
 	held_item.position = Vector3.ZERO
+	# Hide the item. Nobody will know you have it until you use it.
+	held_item.visible=false
 
 @rpc("call_local")
 func use_held_item() -> void:

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -1,7 +1,7 @@
 [gd_scene format=3 uid="uid://bffxe171rcnea"]
 
 [ext_resource type="Script" uid="uid://bx8rb13al7o7e" path="res://player/player.gd" id="1_onrkg"]
-[ext_resource type="Script" path="res://player/player_mesh.gd" id="2_pmesh"]
+[ext_resource type="Script" uid="uid://b0w3b5ncyaqf2" path="res://player/player_mesh.gd" id="2_pmesh"]
 [ext_resource type="Script" uid="uid://dm41gwejdfgy" path="res://player/player_id.gd" id="5_g6k8r"]
 [ext_resource type="PackedScene" uid="uid://c0h4ahbau2lur" path="res://art/3d-assets/Bean.glb" id="5_qjkh3"]
 [ext_resource type="Script" uid="uid://bqpwk0pccci1t" path="res://player/ragdoll.gd" id="6_boad6"]
@@ -117,10 +117,10 @@ transform = Transform3D(1.1906586, 0, 0, 0, 1.1906586, 0, 0, 0, 1.1906586, 0, 0,
 script = ExtResource("2_pmesh")
 rotation_speed_curve = SubResource("Curve_pmesh")
 
-[node name="Bean" parent="Body/Armature/Skeleton3D" parent_id_path=PackedInt32Array(1691841410, 1593713073) index="0" unique_id=685358309]
+[node name="Bean" parent="Body/Armature/Skeleton3D" parent_id_path=PackedInt32Array(1691841410, 819542161) index="0" unique_id=515078765]
 layers = 2
 
-[node name="Bones" type="PhysicalBoneSimulator3D" parent="Body/Armature/Skeleton3D" parent_id_path=PackedInt32Array(1691841410, 1593713073) index="1" unique_id=1885720731]
+[node name="Bones" type="PhysicalBoneSimulator3D" parent="Body/Armature/Skeleton3D" parent_id_path=PackedInt32Array(1691841410, 819542161) index="1" unique_id=1885720731]
 script = ExtResource("6_boad6")
 
 [node name="Physical Bone Pelvis" type="PhysicalBone3D" parent="Body/Armature/Skeleton3D/Bones" unique_id=1014286577]


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #404 

**Summarize what's new, especially anything not mentioned in the issue.**
Gaze upon my one line and weep. Item sets visibility to false once it reparents to you. I left the reparenting logic in there just in case.

**If there's any remaining work needed, describe that here.**
Once it becomes possible to use items and see them doing some animation, we'll need a line of code to make the item visible again!

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Open a scene with a player and an item, pick it up, use it, see nothing! Right click and check the console to see that it does still trigger.