### PR TITLE
Disconnect logic

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -152,8 +152,7 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("scoreboard"):
 		pass
 	if event.is_action_pressed("test1"):
-		# ragdoll_phys.ragdoll(10, true)
-		Multiplayer.delete_disconnected_player(1)
+		ragdoll_phys.ragdoll(10, true)
 	if event.is_action_pressed("print_players"):
 		Debug.print_players()
 	

--- a/systems/multiplayer.gd
+++ b/systems/multiplayer.gd
@@ -97,6 +97,17 @@ func _on_peer_connected(id: int) -> void:
 	# tell the new player about all the other players connected to the server.
 	learn_players.rpc_id(id, player_list)
 
+func disconnect_from_game() -> void:
+	_disconnect_request.rpc_id(1)
+
+@rpc("any_peer", "call_local")
+func _disconnect_request() -> void:
+	if get_multiplayer_authority() != 1: return
+	if player_list.size() == 1:
+		_on_peer_disconnected(1)
+	else:
+		multiplayer.multiplayer_peer.disconnect_peer(multiplayer.get_remote_sender_id())
+
 func _on_peer_disconnected(id : int) -> void:
 	Debug.log(id, " left")
 	if multiplayer.is_server():

--- a/ui/debug_menu/debug_menu.tscn
+++ b/ui/debug_menu/debug_menu.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://bgbsvtifnsja3" path="res://ui/debug_menu/debug_menu.gd" id="1_2lwgs"]
 [ext_resource type="PackedScene" uid="uid://cuxqh6ibre0ni" path="res://ui/debug_menu/debug_scene_button.tscn" id="2_bvele"]
+[ext_resource type="Script" uid="uid://bwijktv11v0b2" path="res://ui/debug_menu/return_buttons.gd" id="3_oh284"]
 
 [node name="DebugMenu" type="CanvasLayer" unique_id=1060676430]
 script = ExtResource("1_2lwgs")
@@ -45,11 +46,13 @@ layout_mode = 2
 [node name="LobbyBrowser" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=2129658815 instance=ExtResource("2_bvele")]
 layout_mode = 2
 text = "Lobby Browser"
-scene_path = "lobby_browser"
+script = ExtResource("3_oh284")
+scene_path = "res://ui/lobby_browser/lobby_browser.tscn"
 
 [node name="MainMenu" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=658329568 instance=ExtResource("2_bvele")]
 layout_mode = 2
 text = "Open Main Menu"
+script = ExtResource("3_oh284")
 scene_path = "res://ui/main_menu/main_menu.tscn"
 
 [node name="Separator" type="Control" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=613846581]

--- a/ui/debug_menu/return_buttons.gd
+++ b/ui/debug_menu/return_buttons.gd
@@ -1,0 +1,10 @@
+extends Button
+
+@export_file_path("*.tscn") var scene_path
+
+func _ready() -> void:
+	pressed.connect(func():
+		ScreenTransition.change_to_file(scene_path)
+		DebugMenu.close_debug_menu()
+		Multiplayer.disconnect_from_game()
+	)

--- a/ui/debug_menu/return_buttons.gd.uid
+++ b/ui/debug_menu/return_buttons.gd.uid
@@ -1,0 +1,1 @@
+uid://bwijktv11v0b2


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #392 

**Summarize what's new, especially anything not mentioned in the issue.**
Implemented disconnect_from_game() function to the multiplayer class.
Implemented the function into the buttons to return to menu or lobby browser from debug menu
Cleans up players who are dc'd.
If the host disconnects everyone is disconnected

**If there's any remaining work needed, describe that here.**


**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Load up 2 instances and then disconnect from one of them. 