### PR TITLE
Correct minigame to play through the last beat in the player attempt

### DIFF
--- a/systems/rhythm/fishing_mini_game.gd
+++ b/systems/rhythm/fishing_mini_game.gd
@@ -118,7 +118,7 @@ func _process(delta: float) -> void:
 			misses+=1
 	
 	if state == Phase.PLAYER_RESPONSE:
-		if rhythm_engine.ms_to_beat(rhythm_engine.current_time_ms) >= 2*TRACK_LENGTH:
+		if rhythm_engine.ms_to_beat(rhythm_engine.current_time_ms) >= (2*TRACK_LENGTH + 1):
 			player_indicator.hide()
 			##Percentage accuracy from 0 to 1
 			var accuracy : float = calculate_accuracy()


### PR DESCRIPTION
Before, the playback would end if the beat was greater than or equal to 2 * TRACK_LENGTH which is 8 beats. However, we want the attempt to play through the last beat, not stop at it. So instead we should end when beat 9 starts.

**What issue does this close? For multiple, write a line for each.**
Closes N/A