### PR TITLE
Sushi player buffs

### DIFF
--- a/fish/sushi/angel_devil_fish.tres
+++ b/fish/sushi/angel_devil_fish.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_piiep")
+fish_name = "Angel & Devil"
 grade = 4
 sprite = ExtResource("2_7g5ue")
 description = "Two fish appear! One on each of your shoulders. To your left is a fish with a devilish grin, and to your right a fish smiles at you, beaming with holy light. They’re your shoulder Devil and Angel– Fish? They compete with each other in guiding you to either sin and temptation or virtue and righteousness! Honestly it’s a bit exhausting to have the two prattling away, telling you to do this or that… Take care to take both of their ideas into great consideration for they both want to steer you in the “right” direction…"

--- a/items/item_rubbermallet/item_rubber_mallet.gd
+++ b/items/item_rubbermallet/item_rubber_mallet.gd
@@ -1,4 +1,4 @@
-extends SwingableItem
+class_name RubberMallet extends SwingableItem
 
 @export var ragdollTime : float = 1.0
 

--- a/player/player.gd
+++ b/player/player.gd
@@ -544,6 +544,7 @@ func buff_player(fish: Fish):
 			# 6 or 7% increase to all stats
 			speed *= 1.06 if randf() < 0.5 else 1.07
 			jump_height *= 1.06 if randf() < 0.5 else 1.07
+			print("%s speed: %f jump: %f Fish seven!" % [name, speed, jump_height])
 			# TODO: what other stats are buffed?
 		"Oh My Cod":
 			# Decrease to the accuracy threshold in the fishing minigame
@@ -551,25 +552,39 @@ func buff_player(fish: Fish):
 			fishing_minigame.fresh_accuracy_requirement -= accuracy_threshold_decrease
 			fishing_minigame.premium_accuracy_requirement -= accuracy_threshold_decrease
 			fishing_minigame.sushi_accuracy_requirement -= accuracy_threshold_decrease
+			print(
+				"%s leftover: %f fresh: %f premium: %f sushi: %f Oh my cod!" % [
+					name,
+					fishing_minigame.leftovers_accuracy_requirement,
+					fishing_minigame.fresh_accuracy_requirement,
+					fishing_minigame.premium_accuracy_requirement,
+					fishing_minigame.sushi_accuracy_requirement
+				]
+			)
 		"Sword Fish":
 			# Increase ragdoll time for enemies you hit
 			swordfish_active = true
+			print("%s Swordfish Active" % name)
 		"Angel & Devil":
 			# 50% chance to buff Jump or Movement
 			if randf() < 0.5:
 				speed += movement_speed_increase
 			else:
 				jump_height += jump_height_increase
+			print("%s Angel (speed): %f devil (jump): %f" % [name, speed, jump_height])
 		"Fish With Legs":
 			# Buff to Movement speed
 			speed += movement_speed_increase
+			print("%s has legs! Speed: %f" % [name, speed])
 		'The "Fish"':
 			# Increased Jump Height
 			jump_height += jump_height_increase
+			print("%s can now jump to %f! Is this really a fish..." % [name, jump_height])
 		"Moai Fish":
 			# Decreased ragdoll time for yourself
 			moai_fish_active = true
 			# The decrease is applied in ragdoll.start_ragdoll()
+			print("%s Moai Active" % name)
 		_:
 			print("No buff exists for %s!" % fish.fish_name)
 

--- a/player/player.gd
+++ b/player/player.gd
@@ -21,6 +21,7 @@ var can_exit_ragdoll := false
 @export var speed := 10.
 var slow_timer := 0.0
 var speed_modifier := 0.0
+var jump_height := 15.
 
 var last_pos : Vector3 = Vector3.ZERO
 var held_item: Item
@@ -69,6 +70,25 @@ var wearing_helmet := false
 var helmet_node : Node = null
 var golden_worm_active := false
 var has_ziplock_bag := false
+
+@export_category("Sushi Grade Buffs")
+## Catching "Oh My Cod" decreases the accuracy thresholds for all
+## fish in the fishing minigame by this amount.
+@export var accuracy_threshold_decrease: float
+## Catching "Swordfish" increases the ragdoll time inflicted on
+## opponents with the Rubber Mallet item by this amount.
+@export var ragdoll_time_increase: float
+var swordfish_active: bool = false
+## Catching "Moai Fish" decreases the ragdoll time inflicted on
+## the player by this amount.
+@export var ragdoll_time_decrease: float
+var moai_fish_active: bool = false
+## Catching "Fish with Legs" or "Angel & Devil" 50% chance
+## buffs the player's movement speed by this amount.
+@export var movement_speed_increase: float
+## Catching "The 'Fish'" or "Angel & Devil" 50% chance
+## increases the player's jump height by this amount.
+@export var jump_height_increase: float
 
 #@onready var livewell : Livewell = $LivewellMenu
 
@@ -122,7 +142,7 @@ func _process(delta: float) -> void:
 		velocity += GRAVITY * delta * Vector3.DOWN
 	
 	if is_on_floor() and Input.is_action_just_pressed("jump") and not UIState.player_keyboard_input_blocked:
-		velocity.y = 15.
+		velocity.y = jump_height
 		_jump_event_id += 1
 		_on_jump_event(_jump_event_id)
 		sync_jump_event.rpc(_jump_event_id)
@@ -419,6 +439,8 @@ func pick_up_item(item: Item) -> void:
 	# Don't play the sound unless we're the owning client
 	if is_multiplayer_authority():
 		$Sounds/PlayerPickupItem.play()
+	if swordfish_active and held_item is RubberMallet:
+		swordfish(held_item)
 
 @rpc("call_local")
 func use_held_item() -> void:
@@ -451,6 +473,8 @@ func give_fish(fish : Fish) -> void:
 	Debug.log("Player " + self.name + " got a " + fish.fish_name)
 	fish_inventory.append(fish)
 	score+=fish.get_score()
+	if fish.grade == Fish.Grade.SUSHI:
+		buff_player(fish)
 	#livewell.addFish(fish)
 	#TODO update livewell ui
 	if is_multiplayer_authority():
@@ -511,3 +535,45 @@ func apply_bone_force(vec : Vector3) -> void:
 		if node is PhysicalBone3D:
 			print("Bone found")
 			node.apply_central_impulse(vec)
+
+## The player is granted specific buffs after catching sushi grade fish.
+func buff_player(fish: Fish):
+	# TODO: Are these buffs stackable?
+	match fish.fish_name:
+		"Fish Seven":
+			# 6 or 7% increase to all stats
+			speed *= 1.06 if randf() < 0.5 else 1.07
+			jump_height *= 1.06 if randf() < 0.5 else 1.07
+			# TODO: what other stats are buffed?
+		"Oh My Cod":
+			# Decrease to the accuracy threshold in the fishing minigame
+			fishing_minigame.leftovers_accuracy_requirement -= accuracy_threshold_decrease
+			fishing_minigame.fresh_accuracy_requirement -= accuracy_threshold_decrease
+			fishing_minigame.premium_accuracy_requirement -= accuracy_threshold_decrease
+			fishing_minigame.sushi_accuracy_requirement -= accuracy_threshold_decrease
+		"Sword Fish":
+			# Increase ragdoll time for enemies you hit
+			swordfish_active = true
+		"Angel & Devil":
+			# 50% chance to buff Jump or Movement
+			if randf() < 0.5:
+				speed += movement_speed_increase
+			else:
+				jump_height += jump_height_increase
+		"Fish With Legs":
+			# Buff to Movement speed
+			speed += movement_speed_increase
+		'The "Fish"':
+			# Increased Jump Height
+			jump_height += jump_height_increase
+		"Moai Fish":
+			# Decreased ragdoll time for yourself
+			moai_fish_active = true
+			# The decrease is applied in ragdoll.start_ragdoll()
+		_:
+			print("No buff exists for %s!" % fish.fish_name)
+
+## The Swordfish increases ragdoll time for enemies the player hits.
+## This will run whenever a rubber mallet is picked up to increase the default time.
+func swordfish(mallet: RubberMallet):
+	mallet.ragdollTime += ragdoll_time_increase

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -144,10 +144,10 @@ mesh = NodePath("PlayerSkeleton/Skeleton3D/DefaultPlayer")
 rotation_speed_curve = ExtResource("4_kb6p2")
 bones = NodePath("PlayerSkeleton/Skeleton3D/Bones")
 
-[node name="DefaultPlayer" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D" parent_id_path=PackedInt32Array(268378426, 1645880762) index="0" unique_id=3456117]
+[node name="DefaultPlayer" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D" parent_id_path=PackedInt32Array(268378426, 468903528) index="0" unique_id=2096271970]
 material_override = SubResource("StandardMaterial3D_x7c3f")
 
-[node name="Bones" type="PhysicalBoneSimulator3D" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D" parent_id_path=PackedInt32Array(268378426, 1645880762) index="1" unique_id=495216820 node_paths=PackedStringArray("player")]
+[node name="Bones" type="PhysicalBoneSimulator3D" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D" parent_id_path=PackedInt32Array(268378426, 468903528) index="1" unique_id=495216820 node_paths=PackedStringArray("player")]
 script = ExtResource("6_boad6")
 player = NodePath("../../../..")
 
@@ -228,12 +228,12 @@ shape = SubResource("SphereShape3D_yllr7")
 debug_color = Color(1, 0, 0.7833333, 1)
 
 [node name="Physical Bone Shoulder L" type="PhysicalBone3D" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D/Bones" unique_id=1590057692]
-transform = Transform3D(-0.0023430062, 0.00027500448, -0.009717752, -0.00040721, -0.009990003, -0.0001845283, -0.009713112, 0.00035248147, 0.0023518624, 0.0013861575, -3.1270254e-05, 0.011039665)
+transform = Transform3D(-0.0023430062, 0.0002750045, -0.009717752, -0.00040721, -0.009990004, -0.0001845283, -0.009713112, 0.00035248147, 0.0023518624, 0.0013861575, -3.1270254e-05, 0.011039665)
 collision_layer = 0
 collision_mask = 9
 joint_type = 2
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.3001542e-05, -0.0004901786, 0.143953)
-body_offset = Transform3D(0.010000001, -2.5320332e-09, -5.2410996e-08, -5.1101324e-08, 3.0559022e-10, -0.009999998, 2.9394869e-09, 0.010000004, 4.3655746e-10, -5.2247196e-07, 0.0014395297, 4.9017253e-06)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.300154e-05, -0.00049017865, 0.14395301)
+body_offset = Transform3D(0.010000001, -2.590241e-09, -5.2410996e-08, -5.1101324e-08, 3.2014214e-10, -0.009999998, 2.9394869e-09, 0.010000003, 4.3655746e-10, -5.2247196e-07, 0.0014395297, 4.9017253e-06)
 bone_name = "Shoulder L"
 joint_constraints/swing_span = 19.999992
 joint_constraints/twist_span = 19.999992
@@ -304,12 +304,12 @@ shape = SubResource("SphereShape3D_yllr7")
 debug_color = Color(1, 0, 0.7833333, 1)
 
 [node name="Physical Bone UpperArm R" type="PhysicalBone3D" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D/Bones" unique_id=486194789]
-transform = Transform3D(-0.008615248, -0.0010656009, 0.0049640727, 0.0005046803, -0.009908584, -0.0012511195, 0.005052012, -0.0008273435, 0.008590269, -0.0032623797, 0.000120492376, 0.009874841)
+transform = Transform3D(-0.008615248, -0.0010656008, 0.0049640727, 0.0005046803, -0.009908584, -0.0012511195, 0.005052012, -0.0008273435, 0.008590269, -0.0032623797, 0.000120492376, 0.009874841)
 collision_layer = 0
 collision_mask = 9
 joint_type = 2
 joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.8740595e-05, 6.264344e-06, 0.09611042)
-body_offset = Transform3D(0.01, 3.4173718e-07, 2.154411e-08, 2.1835149e-08, -1.4272518e-07, -0.010000002, -3.4202822e-07, 0.010000008, -1.4191028e-07, 1.8533319e-07, 0.0009611044, -4.901085e-08)
+body_offset = Transform3D(0.01, 3.418536e-07, 2.154411e-08, 2.1835149e-08, -1.4272518e-07, -0.010000002, -3.4202822e-07, 0.010000008, -1.4191028e-07, 1.8533319e-07, 0.0009611044, -4.901085e-08)
 bone_name = "UpperArm R"
 joint_constraints/swing_span = 19.999992
 joint_constraints/twist_span = 19.999992
@@ -323,12 +323,12 @@ shape = SubResource("SphereShape3D_yllr7")
 debug_color = Color(1, 0, 0.7833333, 1)
 
 [node name="Physical Bone Forearm R" type="PhysicalBone3D" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D/Bones" unique_id=2091765003]
-transform = Transform3D(-0.0081561515, 0.0027557765, 0.005087525, 0.0005903534, -0.008350646, 0.0054697567, 0.0057557537, 0.00476156, 0.006648224, -0.004009396, -4.8686994e-05, 0.008696964)
+transform = Transform3D(-0.0081561515, 0.0027557765, 0.005087525, 0.0005903534, -0.008350645, 0.0054697567, 0.0057557537, 0.0047615594, 0.006648224, -0.004009396, -4.8686994e-05, 0.008696964)
 collision_layer = 0
 collision_mask = 9
 joint_type = 2
 joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.7056553e-05, -1.6932827e-05, 0.052908055)
-body_offset = Transform3D(0.009999996, -8.731149e-10, 1.1263182e-08, 1.0884833e-08, 3.259629e-09, -0.010000002, -3.4924597e-10, 0.01, -3.259629e-09, 5.699694e-07, 0.00052908063, 1.6950071e-07)
+body_offset = Transform3D(0.009999996, -4.656613e-10, 1.1263182e-08, 1.0884833e-08, 2.7939677e-09, -0.010000002, -3.4924597e-10, 0.01, -3.259629e-09, 5.699694e-07, 0.00052908063, 1.6950071e-07)
 bone_name = "Forearm R"
 joint_constraints/swing_span = 19.999992
 joint_constraints/twist_span = 19.999992
@@ -399,12 +399,12 @@ shape = SubResource("SphereShape3D_yllr7")
 debug_color = Color(1, 0, 0.7833333, 1)
 
 [node name="Physical Bone Shin R" type="PhysicalBone3D" parent="DefaultPlayer/PlayerSkeleton/Skeleton3D/Bones" unique_id=2119351414]
-transform = Transform3D(0.0012309741, -0.009906467, 0.0005887508, 0.009864575, 0.0011566562, -0.0011629005, 0.0010839251, 0.0007239276, 0.00991469, -0.0015365831, -0.00015403521, 0.0020237209)
+transform = Transform3D(0.0012309741, -0.009906468, 0.00058875076, 0.009864575, 0.0011566564, -0.0011629005, 0.0010839251, 0.0007239276, 0.00991469, -0.0015365831, -0.00015403521, 0.0020237209)
 collision_layer = 0
 collision_mask = 9
 joint_type = 2
-joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.225206e-06, -9.579791e-06, 0.16513638)
-body_offset = Transform3D(0.010000002, -2.3283064e-09, 1.9790605e-09, 2.2118911e-09, 7.858034e-10, -0.010000003, 4.656613e-10, 0.010000015, 1.3387762e-09, -4.2578904e-08, 0.0016513643, 9.557698e-08)
+joint_offset = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.2252063e-06, -9.578832e-06, 0.16513638)
+body_offset = Transform3D(0.010000002, -2.561137e-09, 1.9790605e-09, 2.2118911e-09, 7.421477e-10, -0.010000003, 4.656613e-10, 0.010000014, 1.2805685e-09, -4.2578904e-08, 0.0016513643, 9.557698e-08)
 bone_name = "Shin R"
 joint_constraints/swing_span = 19.999992
 joint_constraints/twist_span = 19.999992

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -56,6 +56,11 @@ script = ExtResource("1_onrkg")
 player_mesh = NodePath("DefaultPlayer")
 footstep_distance = 3.5
 min_footstep_period = 0.2
+accuracy_threshold_decrease = 5.0
+ragdoll_time_increase = 5.0
+ragdoll_time_decrease = 5.0
+movement_speed_increase = 5.0
+jump_height_increase = 5.0
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." unique_id=1812883740]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)

--- a/player/ragdoll.gd
+++ b/player/ragdoll.gd
@@ -72,6 +72,9 @@ func start_ragdoll(duration: float, prevent_move_check: bool):
 	if prevent_move_check:
 		check_movement_toggle = false
 
+	if player.moai_fish_active:
+		duration -= player.ragdoll_time_decrease
+
 	player.is_ragdolled = true
 	physical_bones_start_simulation()
 

--- a/player/ragdoll.gd
+++ b/player/ragdoll.gd
@@ -74,6 +74,7 @@ func start_ragdoll(duration: float, prevent_move_check: bool):
 
 	if player.moai_fish_active:
 		duration -= player.ragdoll_time_decrease
+	print("%s is ragdolled for %f!" % [player.name, duration])
 
 	player.is_ragdolled = true
 	physical_bones_start_simulation()

--- a/project.godot
+++ b/project.godot
@@ -32,7 +32,7 @@ SceneTransition="*uid://ie0c43cmrtky"
 MainMusicPlayer="*uid://3lris5j0nmj4"
 Livewell="*uid://dyc2qekcn8phe"
 CharacterSelect="*uid://llchqpmwcxj6"
-UIState="*uid://tlyxso62tlvj"
+UIState="*res://ui/ui_state.gd"
 
 [display]
 
@@ -125,6 +125,11 @@ ready_up={
 debug_menu={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":96,"location":0,"echo":false,"script":null)
+]
+}
+Menu={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":49,"location":0,"echo":false,"script":null)
 ]
 }
 options={

--- a/ui/debug_menu/debug_menu.gd
+++ b/ui/debug_menu/debug_menu.gd
@@ -26,3 +26,11 @@ func _process(_delta: float) -> void:
 
 func _on_close_button_pressed() -> void:
 	close_debug_menu()
+
+func _on_sushi_spawner_button_pressed(index: int) -> void:
+	for player: Player in get_tree().get_nodes_in_group("Player"):
+		if player.is_multiplayer_authority():
+			var new_fish = Fish.create(Fish.Grade.SUSHI, index)
+			player.give_fish(new_fish)
+			print("Gave a %s to Player %d!" % [new_fish.fish_name, player.get_multiplayer_authority()])
+			break

--- a/ui/debug_menu/debug_menu.tscn
+++ b/ui/debug_menu/debug_menu.tscn
@@ -2,8 +2,15 @@
 
 [ext_resource type="Script" uid="uid://bgbsvtifnsja3" path="res://ui/debug_menu/debug_menu.gd" id="1_2lwgs"]
 [ext_resource type="PackedScene" uid="uid://cuxqh6ibre0ni" path="res://ui/debug_menu/debug_scene_button.tscn" id="2_bvele"]
+[ext_resource type="Texture2D" uid="uid://tm0h3rinwtna" path="res://fish/sprites/fish_seven.png" id="3_6bvlt"]
+[ext_resource type="Texture2D" uid="uid://cnvc1vghj8m3c" path="res://fish/sprites/oh_my_cod.png" id="4_norta"]
+[ext_resource type="Texture2D" uid="uid://b2x302v0vyb2g" path="res://temp/temp_art/hollow-knight.png" id="5_iqtl5"]
+[ext_resource type="Texture2D" uid="uid://oteep0k5625r" path="res://fish/sprites/angel_devil_fish.png" id="6_cyfjx"]
+[ext_resource type="Texture2D" uid="uid://byhye7monr5cd" path="res://fish/sprites/moai_fish.png" id="7_rpr11"]
+[ext_resource type="Texture2D" uid="uid://dpnd3e2f3wg30" path="res://fish/sprites/the_quote_on_quote_fish.png" id="8_xuwh8"]
 
 [node name="DebugMenu" type="CanvasLayer" unique_id=1060676430]
+layer = 5
 script = ExtResource("1_2lwgs")
 
 [node name="PanelContainer" type="PanelContainer" parent="." unique_id=1623555723]
@@ -13,10 +20,10 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -211.0
-offset_top = -172.0
-offset_right = 211.0
-offset_bottom = 172.0
+offset_left = -266.0
+offset_top = -219.5
+offset_right = 266.0
+offset_bottom = 248.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -65,6 +72,61 @@ layout_mode = 2
 text = "Open Fishing Minigame (test)"
 scene_path = "res://systems/rhythm/fishing_mini_game.tscn"
 
+[node name="Separator3" type="Control" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=1848434056]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="SpawnLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=878795616]
+layout_mode = 2
+text = "Obtain Sushi Fish (for testing buffs)"
+horizontal_alignment = 1
+vertical_alignment = 2
+
+[node name="SushiSpawners" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=1824832003]
+layout_mode = 2
+
+[node name="FishSeven" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners" unique_id=572715356]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Fish7"
+icon = ExtResource("3_6bvlt")
+expand_icon = true
+
+[node name="OhMyCod" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners" unique_id=385209858]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Cod"
+icon = ExtResource("4_norta")
+expand_icon = true
+
+[node name="SwordFish" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners" unique_id=298206860]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Sword"
+icon = ExtResource("5_iqtl5")
+expand_icon = true
+
+[node name="AngelDevil" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners" unique_id=983910604]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "AD"
+icon = ExtResource("6_cyfjx")
+expand_icon = true
+
+[node name="Moai" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners" unique_id=1905884091]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Moai"
+icon = ExtResource("7_rpr11")
+expand_icon = true
+
+[node name="_Fish_" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners" unique_id=419794888]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "\"Fish\""
+icon = ExtResource("8_xuwh8")
+expand_icon = true
+
 [node name="Separator" type="Control" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=613846581]
 layout_mode = 2
 size_flags_vertical = 3
@@ -75,4 +137,10 @@ size_flags_horizontal = 4
 size_flags_vertical = 4
 text = "Close"
 
+[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners/FishSeven" to="." method="_on_sushi_spawner_button_pressed" binds= [1]]
+[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners/OhMyCod" to="." method="_on_sushi_spawner_button_pressed" binds= [4]]
+[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners/SwordFish" to="." method="_on_sushi_spawner_button_pressed" binds= [5]]
+[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners/AngelDevil" to="." method="_on_sushi_spawner_button_pressed" binds= [0]]
+[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners/Moai" to="." method="_on_sushi_spawner_button_pressed" binds= [3]]
+[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/SushiSpawners/_Fish_" to="." method="_on_sushi_spawner_button_pressed" binds= [6]]
 [connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/CloseButton" to="." method="_on_close_button_pressed"]

--- a/ui/ui_state.gd.uid
+++ b/ui/ui_state.gd.uid
@@ -1,1 +1,0 @@
-uid://tlyxso62tlvj


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #627 - Player Buff System

**Summarize what's new, especially anything not mentioned in the issue.**
Catching sushi fish gives the player certain buffs depending on the specific fish caught. There's also new buttons in the debug menu to force add a sushi grade fish to the player's inventory. 

I'm not sure if this was happening for anyone else, but the UIState global autoload kept giving me UID errors, so I changed the autoloads to point to the script path instead of the UID.

**If there's any remaining work needed, describe that here.**
- The buffs currently stack
- The buffs are currently indefinite and do not expire
- I was not sure which of the player's stats are included in Fish Seven's "6 or 7% buff to _all stats_", so currently only speed and jump are buffed
- Ragdoll time increase is only handled for rubber mallets

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
1. Load into a lobby and start a game (2 instances necessary to test ragdoll time)
2. Open the debug menu and add a sushi grade fish to the player's inventory
3. Add a Swordfish and collect a rubber mallet to inflict more ragdoll time on another player
4. Test jump, movement, or ragdoll time based on the fish added