### PR TITLE
fix shift in main menu

### DIFF
--- a/ui/livewell/livewell.gd
+++ b/ui/livewell/livewell.gd
@@ -45,6 +45,8 @@ func update_inventory_visuals(fish_inventory : Array[Fish], new_score : int) -> 
 	
 	
 func _input(event: InputEvent) -> void:
+	if UIState.ui_state == UIState.State.MAIN_MENU:
+		return
 	if event.is_action_pressed("livewell_menu") and not UIState.more_ui_blocked:
 		UIState.ui_state = UIState.State.LIVEWELL
 		show()

--- a/ui/main_menu/main_menu.gd
+++ b/ui/main_menu/main_menu.gd
@@ -12,7 +12,7 @@ func _ready() -> void:
 	Multiplayer.loaded_players.clear()
 	
 	
-	#UIState.ui_state = UIState.State.MAIN_MENU
+	UIState.ui_state = UIState.State.MAIN_MENU
 	Keybinds.load_keybinds()
 	$LobbyBrowser.hide()
 	$Fishdex.hide()

--- a/ui/scoreboard/scoreboard.gd
+++ b/ui/scoreboard/scoreboard.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 		$BackPanel/VBoxContainer/Players.add_child(new_player_score)
 
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("scoreboard"):
+	if event.is_action_pressed("scoreboard") and not UIState.more_ui_blocked:
 		show()
 	elif event.is_action_released("scoreboard"):
 		hide()


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #725 

**Summarize what's new, especially anything not mentioned in the issue.**
Made it so that if in main menu the shift keybind is blocked.
Fixed issue where the tab(scoreboard) was showing in ui_blocked situations

**If there's any remaining work needed, describe that here.**
n/a

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
try clicking shift in the main menu.
Go to the game settings (in the lobby) and try and clicking tab while that menu is up.