### PR TITLE
Added tutorial UI and page resource class

### DIFF
--- a/ui/tutorial/page.gd
+++ b/ui/tutorial/page.gd
@@ -1,0 +1,5 @@
+class_name Page extends Resource
+
+@export var title: String
+@export_multiline var description: String
+@export var image: Texture2D

--- a/ui/tutorial/page.gd.uid
+++ b/ui/tutorial/page.gd.uid
@@ -1,0 +1,1 @@
+uid://6nq2iqnl4gt3

--- a/ui/tutorial/tutorial.gd
+++ b/ui/tutorial/tutorial.gd
@@ -1,0 +1,35 @@
+class_name Tutorial extends Control
+
+@export var tutorial_pages: Array[Page]
+var current_page: int = 0
+
+@onready var page1: Control = $Background/Page
+@onready var page2: Control = $Background/Page2
+
+func _ready() -> void:
+	display_pages()
+
+func _on_right_arrow_pressed() -> void:
+	current_page = clampi(current_page + 2, 0, tutorial_pages.size() - 1)
+	display_pages()
+
+func _on_left_arrow_pressed() -> void:
+	current_page = clampi(current_page - 2, 0, tutorial_pages.size() - 1)
+	display_pages()
+
+func display_pages():
+	page1.get_child(0).text = tutorial_pages[current_page].title
+	page1.get_child(1).text = tutorial_pages[current_page].description
+	page1.get_child(2).texture = tutorial_pages[current_page].image
+
+	if (current_page + 1 < tutorial_pages.size()):
+		page2.get_child(0).text = tutorial_pages[current_page + 1].title
+		page2.get_child(1).text = tutorial_pages[current_page + 1].description
+		page2.get_child(2).texture = tutorial_pages[current_page + 1].image
+	else:
+		page2.get_child(0).text = ""
+		page2.get_child(1).text = ""
+		page2.get_child(2).texture = null
+
+func _on_back_button_pressed() -> void:
+	hide()

--- a/ui/tutorial/tutorial.gd.uid
+++ b/ui/tutorial/tutorial.gd.uid
@@ -1,0 +1,1 @@
+uid://vxybv4dcl8tg

--- a/ui/tutorial/tutorial.tscn
+++ b/ui/tutorial/tutorial.tscn
@@ -1,0 +1,198 @@
+[gd_scene format=3 uid="uid://dygxpoaqm8553"]
+
+[ext_resource type="Theme" uid="uid://b2g0k405s5r7p" path="res://ui/themes/finger_paint.tres" id="1_aybw7"]
+[ext_resource type="Script" uid="uid://vxybv4dcl8tg" path="res://ui/tutorial/tutorial.gd" id="2_3nh40"]
+[ext_resource type="Script" uid="uid://6nq2iqnl4gt3" path="res://ui/tutorial/page.gd" id="3_leiwb"]
+[ext_resource type="Texture2D" uid="uid://bw6cuoglpu530" path="res://ui/itemdex/itemdex-background.png" id="3_lqqlb"]
+[ext_resource type="Texture2D" uid="uid://d0iq6ivnp0gvc" path="res://temp/micheals_mansion/MichealsMansionBackground.webp" id="4_jhac3"]
+[ext_resource type="Texture2D" uid="uid://c7fyt1h4ljmf3" path="res://ui/itemdex/box.png" id="4_pxdlg"]
+[ext_resource type="Theme" uid="uid://dh53sqaw2xh6v" path="res://ui/themes/share_tech_mono.tres" id="4_xpy58"]
+[ext_resource type="Texture2D" uid="uid://bsphqh5kvj7g0" path="res://ui/itemdex/arrow.png" id="5_do47i"]
+[ext_resource type="Texture2D" uid="uid://cw036ankdpuo5" path="res://temp/temp_art/silk.png" id="5_j0hjb"]
+[ext_resource type="Texture2D" uid="uid://dmu8fcsfr37py" path="res://temp/temp_art/catboy.png" id="6_jhac3"]
+[ext_resource type="Texture2D" uid="uid://cjnwf45j1c0rv" path="res://temp/temp_art/king-fisher.png" id="7_vy52c"]
+[ext_resource type="Texture2D" uid="uid://bm7m1kt2nq2q1" path="res://temp/temp_art/ghostfriend.png" id="8_ajco1"]
+[ext_resource type="Texture2D" uid="uid://buwht7m5hgjwk" path="res://fish/sprites/star_fish.png" id="9_u6ate"]
+[ext_resource type="Texture2D" uid="uid://tm0h3rinwtna" path="res://fish/sprites/fish_seven.png" id="10_ss0bh"]
+
+[sub_resource type="Resource" id="Resource_vy52c"]
+script = ExtResource("3_leiwb")
+title = "Page 1"
+description = "sdfjlskdfjsldfjlsdkjfskldjflskdjflskdjfdlksjfsl"
+image = ExtResource("4_jhac3")
+metadata/_custom_type_script = "uid://6nq2iqnl4gt3"
+
+[sub_resource type="Resource" id="Resource_sqq7s"]
+script = ExtResource("3_leiwb")
+title = "Page 2"
+description = "ksjdflksjdlsjdgksldfjsd"
+image = ExtResource("5_j0hjb")
+metadata/_custom_type_script = "uid://6nq2iqnl4gt3"
+
+[sub_resource type="Resource" id="Resource_jg6hm"]
+script = ExtResource("3_leiwb")
+title = "page 3"
+description = "A quart jar of oil mixed with zinc oxide makes a very bright paint."
+image = ExtResource("6_jhac3")
+metadata/_custom_type_script = "uid://6nq2iqnl4gt3"
+
+[sub_resource type="Resource" id="Resource_otvs0"]
+script = ExtResource("3_leiwb")
+title = "Page 4"
+description = "More words go here about how to play the fish game"
+image = ExtResource("7_vy52c")
+metadata/_custom_type_script = "uid://6nq2iqnl4gt3"
+
+[sub_resource type="Resource" id="Resource_6cimi"]
+script = ExtResource("3_leiwb")
+title = "page 5"
+description = "Play with your friends or whatever"
+image = ExtResource("8_ajco1")
+metadata/_custom_type_script = "uid://6nq2iqnl4gt3"
+
+[sub_resource type="Resource" id="Resource_kw5rs"]
+script = ExtResource("3_leiwb")
+title = "page 6"
+description = "Some fish are fishier than the other fish"
+image = ExtResource("9_u6ate")
+metadata/_custom_type_script = "uid://6nq2iqnl4gt3"
+
+[sub_resource type="Resource" id="Resource_wseuc"]
+script = ExtResource("3_leiwb")
+title = "Page 7"
+description = "Fish Seven"
+image = ExtResource("10_ss0bh")
+metadata/_custom_type_script = "uid://6nq2iqnl4gt3"
+
+[node name="Tutorial" type="Control" unique_id=976872789]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_aybw7")
+script = ExtResource("2_3nh40")
+tutorial_pages = Array[ExtResource("3_leiwb")]([SubResource("Resource_vy52c"), SubResource("Resource_sqq7s"), SubResource("Resource_jg6hm"), SubResource("Resource_otvs0"), SubResource("Resource_6cimi"), SubResource("Resource_kw5rs"), SubResource("Resource_wseuc")])
+
+[node name="Background" type="TextureRect" parent="." unique_id=1440524425]
+layout_mode = 0
+offset_right = 1152.0
+offset_bottom = 648.0
+texture = ExtResource("3_lqqlb")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="Page" type="VBoxContainer" parent="Background" unique_id=559845163]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 319.0
+offset_top = 41.0
+offset_right = -598.0
+offset_bottom = -347.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Title" type="Label" parent="Background/Page" unique_id=808158201]
+layout_mode = 2
+theme_type_variation = &"HeaderSmall"
+text = "Chapter Title"
+horizontal_alignment = 1
+
+[node name="Text" type="Label" parent="Background/Page" unique_id=1634702440]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme = ExtResource("4_xpy58")
+theme_type_variation = &"TooltipLabel"
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 0
+text = "Lots of little text here"
+autowrap_mode = 3
+
+[node name="Image" type="TextureRect" parent="Background/Page" unique_id=1335146015]
+layout_mode = 2
+size_flags_vertical = 3
+texture = ExtResource("4_pxdlg")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="Page2" type="VBoxContainer" parent="Background" unique_id=615350727]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 588.0
+offset_top = 41.0
+offset_right = -329.0
+offset_bottom = -347.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Title" type="Label" parent="Background/Page2" unique_id=1512299606]
+layout_mode = 2
+theme_type_variation = &"HeaderSmall"
+text = "Chapter Title"
+horizontal_alignment = 1
+
+[node name="Text" type="Label" parent="Background/Page2" unique_id=1137754849]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme = ExtResource("4_xpy58")
+theme_type_variation = &"TooltipLabel"
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 0
+text = "Lots of little text here"
+autowrap_mode = 3
+
+[node name="Image" type="TextureRect" parent="Background/Page2" unique_id=1241950258]
+layout_mode = 2
+size_flags_vertical = 3
+texture = ExtResource("4_pxdlg")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="RightArrow" type="Button" parent="Background" unique_id=523777718]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 199.0
+offset_top = -49.0
+offset_right = 249.0
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset_ratio = Vector2(0.5, 0.5)
+icon = ExtResource("5_do47i")
+flat = true
+
+[node name="LeftArrow" type="Button" parent="Background" unique_id=1388117822]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -270.0
+offset_top = -59.0
+offset_right = -220.0
+offset_bottom = -9.0
+grow_horizontal = 2
+grow_vertical = 2
+rotation = 3.1415927
+pivot_offset_ratio = Vector2(0.5, 0.5)
+icon = ExtResource("5_do47i")
+flat = true
+
+[node name="Back_Button" type="Button" parent="." unique_id=1148487743]
+layout_mode = 0
+offset_right = 101.935295
+offset_bottom = 68.0
+theme_type_variation = &"FishXButton"
+
+[connection signal="pressed" from="Background/RightArrow" to="." method="_on_right_arrow_pressed"]
+[connection signal="pressed" from="Background/LeftArrow" to="." method="_on_left_arrow_pressed"]
+[connection signal="pressed" from="Back_Button" to="." method="_on_back_button_pressed"]

--- a/ui/tutorial/tutorial.tscn
+++ b/ui/tutorial/tutorial.tscn
@@ -77,8 +77,11 @@ tutorial_pages = Array[ExtResource("3_leiwb")]([SubResource("Resource_vy52c"), S
 
 [node name="Background" type="TextureRect" parent="." unique_id=1440524425]
 layout_mode = 0
-offset_right = 1152.0
-offset_bottom = 648.0
+offset_left = -299.0
+offset_top = 10.0
+offset_right = 853.0
+offset_bottom = 658.0
+scale = Vector2(1.5807521, 1.5807521)
 texture = ExtResource("3_lqqlb")
 expand_mode = 1
 stretch_mode = 5


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #702 - Tutorial Book UI

**Summarize what's new, especially anything not mentioned in the issue.**
There is a scene for the tutorial book UI similar to the itemdex. Each page has a title, description, and image that can be assigned in the inspector.

**If there's any remaining work needed, describe that here.**
The font theme was unclear from the GDD, so tweaking would likely be needed here.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Open `tutorial.tscn`. Each page can be edited in the inspector. When running the scene, the arrows navigate forward and backward in the book, and the fish back button will hide the menu.