### PR TITLE
Updated Premium Tracks

### DIFF
--- a/systems/rhythm/tracks/premium/premium_01.tres
+++ b/systems/rhythm/tracks/premium/premium_01.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://bl5o0pttyykrj"]
 
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_l1clq"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_l1clq"]
 [ext_resource type="AudioStream" uid="uid://qbh8vij5unwm" path="res://systems/rhythm/tracks/backingTrack100.ogg" id="1_nqgt4"]
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="2_sm1nl"]
 
@@ -50,16 +50,6 @@ is_articulated = true
 script = ExtResource("1_l1clq")
 beat_position = 4.0
 
-[sub_resource type="Resource" id="Resource_jxjfm"]
-script = ExtResource("1_l1clq")
-beat_position = 4.333
-is_articulated = true
-
-[sub_resource type="Resource" id="Resource_3ir3k"]
-script = ExtResource("1_l1clq")
-beat_position = 4.666
-is_articulated = true
-
 [sub_resource type="Resource" id="Resource_r8fk4"]
 script = ExtResource("1_l1clq")
 beat_position = 5.0
@@ -106,18 +96,8 @@ beat_position = 8.0
 is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_jydmw"]
-script = ExtResource("1_l1clq")
-beat_position = 8.333
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_1vdus"]
-script = ExtResource("1_l1clq")
-beat_position = 8.666
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
 [resource]
 script = ExtResource("2_sm1nl")
 backing_track = ExtResource("1_nqgt4")
-notes = Array[ExtResource("1_l1clq")]([SubResource("Resource_fngg6"), SubResource("Resource_nwv00"), SubResource("Resource_0nqhx"), SubResource("Resource_kpquo"), SubResource("Resource_vj8pa"), SubResource("Resource_dikqk"), SubResource("Resource_b7est"), SubResource("Resource_l1clq"), SubResource("Resource_sm1nl"), SubResource("Resource_h8as3"), SubResource("Resource_jxjfm"), SubResource("Resource_3ir3k"), SubResource("Resource_r8fk4"), SubResource("Resource_b18hc"), SubResource("Resource_omp8e"), SubResource("Resource_6ie5i"), SubResource("Resource_rdprt"), SubResource("Resource_ahcs3"), SubResource("Resource_j2nt6"), SubResource("Resource_po6p8"), SubResource("Resource_n0n3a"), SubResource("Resource_cy23h"), SubResource("Resource_jydmw"), SubResource("Resource_1vdus")])
+notes = Array[ExtResource("1_l1clq")]([SubResource("Resource_fngg6"), SubResource("Resource_nwv00"), SubResource("Resource_0nqhx"), SubResource("Resource_kpquo"), SubResource("Resource_vj8pa"), SubResource("Resource_dikqk"), SubResource("Resource_b7est"), SubResource("Resource_l1clq"), SubResource("Resource_sm1nl"), SubResource("Resource_h8as3"), SubResource("Resource_r8fk4"), SubResource("Resource_b18hc"), SubResource("Resource_omp8e"), SubResource("Resource_6ie5i"), SubResource("Resource_rdprt"), SubResource("Resource_ahcs3"), SubResource("Resource_j2nt6"), SubResource("Resource_po6p8"), SubResource("Resource_n0n3a"), SubResource("Resource_cy23h")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"

--- a/systems/rhythm/tracks/premium/premium_02.tres
+++ b/systems/rhythm/tracks/premium/premium_02.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://cvaiaa707xfor"]
 
 [ext_resource type="AudioStream" uid="uid://qbh8vij5unwm" path="res://systems/rhythm/tracks/backingTrack100.ogg" id="1_bp8oa"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_e22ep"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_e22ep"]
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="2_bp8oa"]
 
 [sub_resource type="Resource" id="Resource_e22ep"]
@@ -33,13 +33,7 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_ubp3g"]
 script = ExtResource("1_e22ep")
-beat_position = 3.333
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_mmcj2"]
-script = ExtResource("1_e22ep")
-beat_position = 3.666
-is_articulated = true
+beat_position = 3.5
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_73bav"]
@@ -50,13 +44,7 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_6kr1m"]
 script = ExtResource("1_e22ep")
-beat_position = 4.333
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_77heu"]
-script = ExtResource("1_e22ep")
-beat_position = 4.666
-is_articulated = true
+beat_position = 4.5
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_b5ogt"]
@@ -83,39 +71,21 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 [sub_resource type="Resource" id="Resource_xox2q"]
 script = ExtResource("1_e22ep")
 beat_position = 7.0
-is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_2swcp"]
 script = ExtResource("1_e22ep")
-beat_position = 7.333
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_7hryc"]
-script = ExtResource("1_e22ep")
-beat_position = 7.666
+beat_position = 7.5
 is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_30ut7"]
 script = ExtResource("1_e22ep")
 beat_position = 8.0
-is_articulated = true
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_2k5a8"]
-script = ExtResource("1_e22ep")
-beat_position = 8.333
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_h6ver"]
-script = ExtResource("1_e22ep")
-beat_position = 8.666
-is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [resource]
 script = ExtResource("2_bp8oa")
 backing_track = ExtResource("1_bp8oa")
-notes = Array[ExtResource("1_e22ep")]([SubResource("Resource_e22ep"), SubResource("Resource_bp8oa"), SubResource("Resource_mjog5"), SubResource("Resource_ls8ii"), SubResource("Resource_addb4"), SubResource("Resource_ubp3g"), SubResource("Resource_mmcj2"), SubResource("Resource_73bav"), SubResource("Resource_6kr1m"), SubResource("Resource_77heu"), SubResource("Resource_b5ogt"), SubResource("Resource_3vlie"), SubResource("Resource_yq46i"), SubResource("Resource_w0nsb"), SubResource("Resource_xox2q"), SubResource("Resource_2swcp"), SubResource("Resource_7hryc"), SubResource("Resource_30ut7"), SubResource("Resource_2k5a8"), SubResource("Resource_h6ver")])
+notes = Array[ExtResource("1_e22ep")]([SubResource("Resource_e22ep"), SubResource("Resource_bp8oa"), SubResource("Resource_mjog5"), SubResource("Resource_ls8ii"), SubResource("Resource_addb4"), SubResource("Resource_ubp3g"), SubResource("Resource_73bav"), SubResource("Resource_6kr1m"), SubResource("Resource_b5ogt"), SubResource("Resource_3vlie"), SubResource("Resource_yq46i"), SubResource("Resource_w0nsb"), SubResource("Resource_xox2q"), SubResource("Resource_2swcp"), SubResource("Resource_30ut7")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"

--- a/systems/rhythm/tracks/premium/premium_03.tres
+++ b/systems/rhythm/tracks/premium/premium_03.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://brj5yd01xjoyj"]
 
-[ext_resource type="AudioStream" uid="uid://dv8tsjlaockcf" path="res://systems/rhythm/tracks/backingTrack80.ogg" id="1_cyyo6"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_t70me"]
+[ext_resource type="AudioStream" uid="uid://bbqsah8ks5u6" path="res://systems/rhythm/tracks/backingTrack120.ogg" id="1_5didp"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_t70me"]
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="2_cyyo6"]
 
 [sub_resource type="Resource" id="Resource_fngg6"]
@@ -62,19 +62,13 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_uelfb"]
 script = ExtResource("1_t70me")
-beat_position = 7.666
-is_articulated = true
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_1mj6a"]
-script = ExtResource("1_t70me")
-beat_position = 8.333
+beat_position = 8.0
 is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [resource]
 script = ExtResource("2_cyyo6")
-bpm = 80.0
-backing_track = ExtResource("1_cyyo6")
-notes = Array[ExtResource("1_t70me")]([SubResource("Resource_fngg6"), SubResource("Resource_nwv00"), SubResource("Resource_0nqhx"), SubResource("Resource_kpquo"), SubResource("Resource_vj8pa"), SubResource("Resource_dikqk"), SubResource("Resource_b7est"), SubResource("Resource_b7iuy"), SubResource("Resource_t70me"), SubResource("Resource_cyyo6"), SubResource("Resource_uelfb"), SubResource("Resource_1mj6a")])
+bpm = 120.0
+backing_track = ExtResource("1_5didp")
+notes = Array[ExtResource("1_t70me")]([SubResource("Resource_fngg6"), SubResource("Resource_nwv00"), SubResource("Resource_0nqhx"), SubResource("Resource_kpquo"), SubResource("Resource_vj8pa"), SubResource("Resource_dikqk"), SubResource("Resource_b7est"), SubResource("Resource_b7iuy"), SubResource("Resource_t70me"), SubResource("Resource_cyyo6"), SubResource("Resource_uelfb")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"

--- a/systems/rhythm/tracks/premium/premium_04.tres
+++ b/systems/rhythm/tracks/premium/premium_04.tres
@@ -1,8 +1,8 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://ds1lhpurqpk1n"]
 
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="1_6yxs5"]
-[ext_resource type="AudioStream" uid="uid://qbh8vij5unwm" path="res://systems/rhythm/tracks/backingTrack100.ogg" id="1_j0t8p"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
+[ext_resource type="AudioStream" uid="uid://bbqsah8ks5u6" path="res://systems/rhythm/tracks/backingTrack120.ogg" id="1_pjaes"]
 
 [sub_resource type="Resource" id="Resource_0"]
 script = ExtResource("1_n2fmx")
@@ -20,80 +20,69 @@ beat_position = 2.5
 is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_3"]
-script = ExtResource("1_n2fmx")
-beat_position = 3.25
-is_articulated = true
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
 [sub_resource type="Resource" id="Resource_4"]
 script = ExtResource("1_n2fmx")
-beat_position = 4.0
+beat_position = 3.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_5"]
+script = ExtResource("1_n2fmx")
+beat_position = 3.5
+metadata/_custom_type_script = "uid://bc1rjslobm0p6"
+
+[sub_resource type="Resource" id="Resource_7"]
+script = ExtResource("1_n2fmx")
+beat_position = 4.0
+is_articulated = true
+metadata/_custom_type_script = "uid://bc1rjslobm0p6"
+
+[sub_resource type="Resource" id="Resource_8"]
 script = ExtResource("1_n2fmx")
 beat_position = 5.0
 is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_6"]
-script = ExtResource("1_n2fmx")
-beat_position = 5.25
-is_articulated = true
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_7"]
+[sub_resource type="Resource" id="Resource_10"]
 script = ExtResource("1_n2fmx")
 beat_position = 5.5
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_8"]
+[sub_resource type="Resource" id="Resource_11"]
 script = ExtResource("1_n2fmx")
 beat_position = 6.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_9"]
+[sub_resource type="Resource" id="Resource_13"]
 script = ExtResource("1_n2fmx")
 beat_position = 6.5
 is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_10"]
-script = ExtResource("1_n2fmx")
-beat_position = 6.75
-is_articulated = true
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_11"]
-script = ExtResource("1_n2fmx")
-beat_position = 7.0
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_12"]
-script = ExtResource("1_n2fmx")
-beat_position = 7.5
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_13"]
-script = ExtResource("1_n2fmx")
-beat_position = 8.0
-is_articulated = true
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
 [sub_resource type="Resource" id="Resource_14"]
 script = ExtResource("1_n2fmx")
-beat_position = 8.25
+beat_position = 7.0
 is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_15"]
 script = ExtResource("1_n2fmx")
-beat_position = 8.5
+beat_position = 7.25
+is_articulated = true
+metadata/_custom_type_script = "uid://bc1rjslobm0p6"
+
+[sub_resource type="Resource" id="Resource_pjaes"]
+script = ExtResource("1_n2fmx")
+beat_position = 7.5
+metadata/_custom_type_script = "uid://bc1rjslobm0p6"
+
+[sub_resource type="Resource" id="Resource_x27a8"]
+script = ExtResource("1_n2fmx")
+beat_position = 8.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [resource]
 script = ExtResource("1_6yxs5")
-backing_track = ExtResource("1_j0t8p")
-notes = Array[ExtResource("1_n2fmx")]([SubResource("Resource_0"), SubResource("Resource_1"), SubResource("Resource_2"), SubResource("Resource_3"), SubResource("Resource_4"), SubResource("Resource_5"), SubResource("Resource_6"), SubResource("Resource_7"), SubResource("Resource_8"), SubResource("Resource_9"), SubResource("Resource_10"), SubResource("Resource_11"), SubResource("Resource_12"), SubResource("Resource_13"), SubResource("Resource_14"), SubResource("Resource_15")])
+bpm = 120.0
+backing_track = ExtResource("1_pjaes")
+notes = Array[ExtResource("1_n2fmx")]([SubResource("Resource_0"), SubResource("Resource_1"), SubResource("Resource_2"), SubResource("Resource_4"), SubResource("Resource_5"), SubResource("Resource_7"), SubResource("Resource_8"), SubResource("Resource_10"), SubResource("Resource_11"), SubResource("Resource_13"), SubResource("Resource_14"), SubResource("Resource_15"), SubResource("Resource_pjaes"), SubResource("Resource_x27a8")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"

--- a/systems/rhythm/tracks/premium/premium_05.tres
+++ b/systems/rhythm/tracks/premium/premium_05.tres
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="1_6yxs5"]
 [ext_resource type="AudioStream" uid="uid://bbqsah8ks5u6" path="res://systems/rhythm/tracks/backingTrack120.ogg" id="1_jeq0f"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
 
 [sub_resource type="Resource" id="Resource_0"]
 script = ExtResource("1_n2fmx")
@@ -84,7 +84,7 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_14"]
 script = ExtResource("1_n2fmx")
-beat_position = 8.5
+beat_position = 8.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [resource]

--- a/systems/rhythm/tracks/premium/premium_06.tres
+++ b/systems/rhythm/tracks/premium/premium_06.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://c5bs3sq24hev3"]
 
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="1_6yxs5"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
 [ext_resource type="AudioStream" uid="uid://bbqsah8ks5u6" path="res://systems/rhythm/tracks/backingTrack120.ogg" id="1_wg0k1"]
 
 [sub_resource type="Resource" id="Resource_0"]

--- a/systems/rhythm/tracks/premium/premium_07.tres
+++ b/systems/rhythm/tracks/premium/premium_07.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://dv3j8mp1lp52f"]
 
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="1_6yxs5"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_n2fmx"]
 [ext_resource type="AudioStream" uid="uid://j6qwvitvs2uk" path="res://systems/rhythm/tracks/backingTrack140.ogg" id="1_rueg6"]
 
 [sub_resource type="Resource" id="Resource_0"]
@@ -26,7 +26,7 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_4"]
 script = ExtResource("1_n2fmx")
-beat_position = 3.75
+beat_position = 4.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_5"]
@@ -57,7 +57,7 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_10"]
 script = ExtResource("1_n2fmx")
-beat_position = 7.75
+beat_position = 8.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [resource]

--- a/systems/rhythm/tracks/premium/premium_08.tres
+++ b/systems/rhythm/tracks/premium/premium_08.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://cxt7yuyw5mb64"]
 
 [ext_resource type="AudioStream" uid="uid://qbh8vij5unwm" path="res://systems/rhythm/tracks/backingTrack100.ogg" id="1_bsgve"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_kpp1d"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_kpp1d"]
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="2_bsgve"]
 
 [sub_resource type="Resource" id="Resource_kpp1d"]
@@ -11,12 +11,13 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_bsgve"]
 script = ExtResource("1_kpp1d")
-beat_position = 1.75
+beat_position = 2.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_r6p1o"]
 script = ExtResource("1_kpp1d")
-beat_position = 2.0
+beat_position = 2.25
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_wlpw4"]
@@ -27,6 +28,7 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 [sub_resource type="Resource" id="Resource_ccal2"]
 script = ExtResource("1_kpp1d")
 beat_position = 2.75
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_en3sn"]
@@ -34,37 +36,27 @@ script = ExtResource("1_kpp1d")
 beat_position = 3.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_dk65g"]
-script = ExtResource("1_kpp1d")
-beat_position = 3.25
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
 [sub_resource type="Resource" id="Resource_fal0w"]
 script = ExtResource("1_kpp1d")
-beat_position = 3.75
+beat_position = 4.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_8n1y7"]
 script = ExtResource("1_kpp1d")
-beat_position = 4.5
+beat_position = 5.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_w7l8l"]
 script = ExtResource("1_kpp1d")
-beat_position = 4.75
+beat_position = 5.25
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_oli63"]
 script = ExtResource("1_kpp1d")
-beat_position = 5.25
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_tao2l"]
-script = ExtResource("1_kpp1d")
 beat_position = 5.5
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
-[sub_resource type="Resource" id="Resource_votnb"]
+[sub_resource type="Resource" id="Resource_tao2l"]
 script = ExtResource("1_kpp1d")
 beat_position = 5.75
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
@@ -72,60 +64,56 @@ metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 [sub_resource type="Resource" id="Resource_62bnp"]
 script = ExtResource("1_kpp1d")
 beat_position = 6.0
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_5ov0h"]
 script = ExtResource("1_kpp1d")
-beat_position = 6.5
+beat_position = 6.25
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_6ekm4"]
 script = ExtResource("1_kpp1d")
-beat_position = 6.75
+beat_position = 6.5
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_8ag2q"]
 script = ExtResource("1_kpp1d")
-beat_position = 7.0
+beat_position = 6.75
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_ao0hv"]
 script = ExtResource("1_kpp1d")
-beat_position = 7.5
+beat_position = 7.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_7ewvd"]
 script = ExtResource("1_kpp1d")
-beat_position = 7.625
+beat_position = 7.25
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_83jms"]
 script = ExtResource("1_kpp1d")
-beat_position = 7.75
+beat_position = 7.5
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_hot6j"]
 script = ExtResource("1_kpp1d")
-beat_position = 8.0
+beat_position = 7.75
+is_articulated = true
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [sub_resource type="Resource" id="Resource_0p5iq"]
 script = ExtResource("1_kpp1d")
-beat_position = 8.125
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_mhkha"]
-script = ExtResource("1_kpp1d")
-beat_position = 8.25
-metadata/_custom_type_script = "uid://bc1rjslobm0p6"
-
-[sub_resource type="Resource" id="Resource_4u78t"]
-script = ExtResource("1_kpp1d")
-beat_position = 8.5
+beat_position = 8.0
 metadata/_custom_type_script = "uid://bc1rjslobm0p6"
 
 [resource]
 script = ExtResource("2_bsgve")
 backing_track = ExtResource("1_bsgve")
-notes = Array[ExtResource("1_kpp1d")]([SubResource("Resource_kpp1d"), SubResource("Resource_bsgve"), SubResource("Resource_r6p1o"), SubResource("Resource_wlpw4"), SubResource("Resource_ccal2"), SubResource("Resource_en3sn"), SubResource("Resource_dk65g"), SubResource("Resource_fal0w"), SubResource("Resource_8n1y7"), SubResource("Resource_w7l8l"), SubResource("Resource_oli63"), SubResource("Resource_tao2l"), SubResource("Resource_votnb"), SubResource("Resource_62bnp"), SubResource("Resource_5ov0h"), SubResource("Resource_6ekm4"), SubResource("Resource_8ag2q"), SubResource("Resource_ao0hv"), SubResource("Resource_7ewvd"), SubResource("Resource_83jms"), SubResource("Resource_hot6j"), SubResource("Resource_0p5iq"), SubResource("Resource_mhkha"), SubResource("Resource_4u78t")])
+notes = Array[ExtResource("1_kpp1d")]([SubResource("Resource_kpp1d"), SubResource("Resource_bsgve"), SubResource("Resource_r6p1o"), SubResource("Resource_wlpw4"), SubResource("Resource_ccal2"), SubResource("Resource_en3sn"), SubResource("Resource_fal0w"), SubResource("Resource_8n1y7"), SubResource("Resource_w7l8l"), SubResource("Resource_oli63"), SubResource("Resource_tao2l"), SubResource("Resource_62bnp"), SubResource("Resource_5ov0h"), SubResource("Resource_6ekm4"), SubResource("Resource_8ag2q"), SubResource("Resource_ao0hv"), SubResource("Resource_7ewvd"), SubResource("Resource_83jms"), SubResource("Resource_hot6j"), SubResource("Resource_0p5iq")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"

--- a/systems/rhythm/tracks/premium/premium_09.tres
+++ b/systems/rhythm/tracks/premium/premium_09.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://c5gt3jhk7fsod"]
 
-[ext_resource type="AudioStream" uid="uid://qbh8vij5unwm" path="res://systems/rhythm/tracks/backingTrack100.ogg" id="1_i0bhn"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_ivo47"]
+[ext_resource type="AudioStream" uid="uid://bbqsah8ks5u6" path="res://systems/rhythm/tracks/backingTrack120.ogg" id="1_bnmxw"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_ivo47"]
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="2_i0bhn"]
 
 [sub_resource type="Resource" id="Resource_ivo47"]
@@ -15,6 +15,7 @@ beat_position = 2.0
 [sub_resource type="Resource" id="Resource_0v4xk"]
 script = ExtResource("1_ivo47")
 beat_position = 2.333
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_lwb30"]
 script = ExtResource("1_ivo47")
@@ -23,6 +24,7 @@ beat_position = 2.666
 [sub_resource type="Resource" id="Resource_h11wl"]
 script = ExtResource("1_ivo47")
 beat_position = 3.0
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_0vpg2"]
 script = ExtResource("1_ivo47")
@@ -39,10 +41,12 @@ beat_position = 4.5
 [sub_resource type="Resource" id="Resource_d24o7"]
 script = ExtResource("1_ivo47")
 beat_position = 5.0
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_dyepb"]
 script = ExtResource("1_ivo47")
 beat_position = 6.0
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_k1mhy"]
 script = ExtResource("1_ivo47")
@@ -51,6 +55,7 @@ beat_position = 6.333
 [sub_resource type="Resource" id="Resource_7k8ar"]
 script = ExtResource("1_ivo47")
 beat_position = 6.666
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_ahjth"]
 script = ExtResource("1_ivo47")
@@ -59,17 +64,15 @@ beat_position = 7.0
 [sub_resource type="Resource" id="Resource_ksl2i"]
 script = ExtResource("1_ivo47")
 beat_position = 7.5
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_cqkom"]
 script = ExtResource("1_ivo47")
 beat_position = 8.0
 
-[sub_resource type="Resource" id="Resource_ueim3"]
-script = ExtResource("1_ivo47")
-beat_position = 8.5
-
 [resource]
 script = ExtResource("2_i0bhn")
-backing_track = ExtResource("1_i0bhn")
-notes = Array[ExtResource("1_ivo47")]([SubResource("Resource_ivo47"), SubResource("Resource_i0bhn"), SubResource("Resource_0v4xk"), SubResource("Resource_lwb30"), SubResource("Resource_h11wl"), SubResource("Resource_0vpg2"), SubResource("Resource_glu8x"), SubResource("Resource_0d21k"), SubResource("Resource_d24o7"), SubResource("Resource_dyepb"), SubResource("Resource_k1mhy"), SubResource("Resource_7k8ar"), SubResource("Resource_ahjth"), SubResource("Resource_ksl2i"), SubResource("Resource_cqkom"), SubResource("Resource_ueim3")])
+bpm = 120.0
+backing_track = ExtResource("1_bnmxw")
+notes = Array[ExtResource("1_ivo47")]([SubResource("Resource_ivo47"), SubResource("Resource_i0bhn"), SubResource("Resource_0v4xk"), SubResource("Resource_lwb30"), SubResource("Resource_h11wl"), SubResource("Resource_0vpg2"), SubResource("Resource_glu8x"), SubResource("Resource_0d21k"), SubResource("Resource_d24o7"), SubResource("Resource_dyepb"), SubResource("Resource_k1mhy"), SubResource("Resource_7k8ar"), SubResource("Resource_ahjth"), SubResource("Resource_ksl2i"), SubResource("Resource_cqkom")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"

--- a/systems/rhythm/tracks/premium/premium_10.tres
+++ b/systems/rhythm/tracks/premium/premium_10.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://dmfgppf5bntil"]
 
-[ext_resource type="AudioStream" uid="uid://qbh8vij5unwm" path="res://systems/rhythm/tracks/backingTrack100.ogg" id="1_ba0p6"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_vbsgx"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_vbsgx"]
+[ext_resource type="AudioStream" uid="uid://j6qwvitvs2uk" path="res://systems/rhythm/tracks/backingTrack140.ogg" id="1_yklt7"]
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="2_ba0p6"]
 
 [sub_resource type="Resource" id="Resource_vbsgx"]
@@ -10,54 +10,48 @@ beat_position = 1.0
 
 [sub_resource type="Resource" id="Resource_ba0p6"]
 script = ExtResource("1_vbsgx")
-beat_position = 4.0
+beat_position = 2.0
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_h76xp"]
 script = ExtResource("1_vbsgx")
-beat_position = 4.75
+beat_position = 3.0
 
 [sub_resource type="Resource" id="Resource_f8js0"]
 script = ExtResource("1_vbsgx")
-beat_position = 5.0
+beat_position = 3.5
 
 [sub_resource type="Resource" id="Resource_i2mf4"]
 script = ExtResource("1_vbsgx")
-beat_position = 5.25
+beat_position = 4.0
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_m38vc"]
 script = ExtResource("1_vbsgx")
-beat_position = 5.5
+beat_position = 5.0
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_h4drh"]
 script = ExtResource("1_vbsgx")
 beat_position = 6.0
 
-[sub_resource type="Resource" id="Resource_bei6c"]
-script = ExtResource("1_vbsgx")
-beat_position = 6.5
-
 [sub_resource type="Resource" id="Resource_1qdpu"]
 script = ExtResource("1_vbsgx")
 beat_position = 7.0
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_2yel4"]
 script = ExtResource("1_vbsgx")
-beat_position = 7.25
-
-[sub_resource type="Resource" id="Resource_j0xes"]
-script = ExtResource("1_vbsgx")
 beat_position = 7.5
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_rftrb"]
 script = ExtResource("1_vbsgx")
 beat_position = 8.0
 
-[sub_resource type="Resource" id="Resource_w60b5"]
-script = ExtResource("1_vbsgx")
-beat_position = 8.5
-
 [resource]
 script = ExtResource("2_ba0p6")
-backing_track = ExtResource("1_ba0p6")
-notes = Array[ExtResource("1_vbsgx")]([SubResource("Resource_vbsgx"), SubResource("Resource_ba0p6"), SubResource("Resource_h76xp"), SubResource("Resource_f8js0"), SubResource("Resource_i2mf4"), SubResource("Resource_m38vc"), SubResource("Resource_h4drh"), SubResource("Resource_bei6c"), SubResource("Resource_1qdpu"), SubResource("Resource_2yel4"), SubResource("Resource_j0xes"), SubResource("Resource_rftrb"), SubResource("Resource_w60b5")])
+bpm = 140.0
+backing_track = ExtResource("1_yklt7")
+notes = Array[ExtResource("1_vbsgx")]([SubResource("Resource_vbsgx"), SubResource("Resource_ba0p6"), SubResource("Resource_h76xp"), SubResource("Resource_f8js0"), SubResource("Resource_i2mf4"), SubResource("Resource_m38vc"), SubResource("Resource_h4drh"), SubResource("Resource_1qdpu"), SubResource("Resource_2yel4"), SubResource("Resource_rftrb")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"

--- a/systems/rhythm/tracks/premium/premium_11.tres
+++ b/systems/rhythm/tracks/premium/premium_11.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="Track" format=3 uid="uid://c864km3ic82bq"]
 
-[ext_resource type="AudioStream" uid="uid://qbh8vij5unwm" path="res://systems/rhythm/tracks/backingTrack100.ogg" id="1_i0bhn"]
-[ext_resource type="Script" path="res://systems/rhythm/note.gd" id="1_ivo47"]
+[ext_resource type="Script" uid="uid://bc1rjslobm0p6" path="res://systems/rhythm/note.gd" id="1_ivo47"]
+[ext_resource type="AudioStream" uid="uid://j6qwvitvs2uk" path="res://systems/rhythm/tracks/backingTrack140.ogg" id="1_x86xd"]
 [ext_resource type="Script" uid="uid://duodpj15swkyd" path="res://systems/rhythm/tracks/track.gd" id="2_i0bhn"]
 
 [sub_resource type="Resource" id="Resource_ivo47"]
@@ -14,27 +14,17 @@ beat_position = 2.0
 
 [sub_resource type="Resource" id="Resource_0v4xk"]
 script = ExtResource("1_ivo47")
-beat_position = 2.333
+beat_position = 2.666
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_lwb30"]
 script = ExtResource("1_ivo47")
-beat_position = 2.666
+beat_position = 3.333
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_h11wl"]
 script = ExtResource("1_ivo47")
-beat_position = 3.0
-
-[sub_resource type="Resource" id="Resource_0vpg2"]
-script = ExtResource("1_ivo47")
-beat_position = 3.5
-
-[sub_resource type="Resource" id="Resource_glu8x"]
-script = ExtResource("1_ivo47")
 beat_position = 4.0
-
-[sub_resource type="Resource" id="Resource_0d21k"]
-script = ExtResource("1_ivo47")
-beat_position = 4.5
 
 [sub_resource type="Resource" id="Resource_d24o7"]
 script = ExtResource("1_ivo47")
@@ -46,30 +36,25 @@ beat_position = 6.0
 
 [sub_resource type="Resource" id="Resource_k1mhy"]
 script = ExtResource("1_ivo47")
-beat_position = 6.333
+beat_position = 6.666
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_7k8ar"]
 script = ExtResource("1_ivo47")
-beat_position = 6.666
+beat_position = 7.333
+is_articulated = true
 
 [sub_resource type="Resource" id="Resource_ahjth"]
 script = ExtResource("1_ivo47")
-beat_position = 7.0
-
-[sub_resource type="Resource" id="Resource_ksl2i"]
-script = ExtResource("1_ivo47")
-beat_position = 7.5
+beat_position = 8.0
 
 [sub_resource type="Resource" id="Resource_cqkom"]
 script = ExtResource("1_ivo47")
 beat_position = 8.0
 
-[sub_resource type="Resource" id="Resource_ueim3"]
-script = ExtResource("1_ivo47")
-beat_position = 8.5
-
 [resource]
 script = ExtResource("2_i0bhn")
-backing_track = ExtResource("1_i0bhn")
-notes = Array[ExtResource("1_ivo47")]([SubResource("Resource_ivo47"), SubResource("Resource_i0bhn"), SubResource("Resource_0v4xk"), SubResource("Resource_lwb30"), SubResource("Resource_h11wl"), SubResource("Resource_0vpg2"), SubResource("Resource_glu8x"), SubResource("Resource_0d21k"), SubResource("Resource_d24o7"), SubResource("Resource_dyepb"), SubResource("Resource_k1mhy"), SubResource("Resource_7k8ar"), SubResource("Resource_ahjth"), SubResource("Resource_ksl2i"), SubResource("Resource_cqkom"), SubResource("Resource_ueim3")])
+bpm = 140.0
+backing_track = ExtResource("1_x86xd")
+notes = Array[ExtResource("1_ivo47")]([SubResource("Resource_ivo47"), SubResource("Resource_i0bhn"), SubResource("Resource_0v4xk"), SubResource("Resource_lwb30"), SubResource("Resource_h11wl"), SubResource("Resource_d24o7"), SubResource("Resource_dyepb"), SubResource("Resource_k1mhy"), SubResource("Resource_7k8ar"), SubResource("Resource_ahjth"), SubResource("Resource_cqkom")])
 metadata/_custom_type_script = "uid://duodpj15swkyd"


### PR DESCRIPTION
Reworked Premium Tracks:
3-1: Removed the notes at 4.33, 4.66, 8.33, and 8.66, to give the player some breathing room for transitions, and to implement the “last 8” rule
3-2: Reduced the triplets on beats 3,4, 7 and 8 to eighth-notes and implemented the “last 8” rule
3-3: Implemented the “last 8” rule, and switched the tempo from 80 to 120 to make the track more energizing
3-4: Removed most of the 16th notes, switched the tempo from 100 to 120, and applied the “last 8” rule
3-5: Applied the “last 8” Rule
3-6: Left as is, no changes needed
3-7: Changed the notes that were on 3.75 and 7.75 to 4 and 8 respectively.
3-8: REWORK: Removed 32nd notes, first half is more relaxing, alt notes are implemented to make a pattern in the second half, implements the “last 8” rule.
3-9: Added some alt notes, applied the “last 8” rule, changed tempo to 120
3-10: REWORK: Applied “last 8” rule, changed tempo from 100 to 140, removed all 16th notes, added alt notes (if the tempo was lower, this would be suitable for a fresh or even leftover)
3-11: REWORK: Slowed triplets to make it similar to 3-3, turned tempo to 140, added alt notes


**What issue does this close? For multiple, write a line for each.**
This is the Premium's Rarity with the new "Last 8" Rule going into effect (8 being the last note)

**Summarize what's new, especially anything not mentioned in the issue.**
...

**If there's any remaining work needed, describe that here.**
Adjust Fresh and Leftover Fishes (might be done Saturday)

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
... Fishing Minigame Test